### PR TITLE
Update license in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
   "version": "1.2.3",
   "source": "git clone https://github.com/echocat/puppet-redis.git",
   "author": "Daniel Werdermann",
-  "license": "Mozilla Public License Version 2.0",
+  "license": "MPL-2.0",
   "summary": "Install and configure redis and sentinel from repo or source",
   "project_page": "https://github.com/echocat/puppet-redis",
   "issues_url": "https://github.com/echocat/puppet-redis/issues",


### PR DESCRIPTION
I noticed "Unrecognized license in metadata" in https://forge.puppetlabs.com/dwerder/redis/scores .

The identifier this -- https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#fields-in-metadatajson -- looks to match seems to be the identifier column (rather than name) here -- http://spdx.org/licenses/ -- which for some reason is called a short_identifier here -- http://spdx.org/licenses/MPL-2.0 .
