### PR TITLE
Add Support for SLES

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,11 @@ Name of database dump file. Default: dump.rdb
 Default is '/var/lib' (string)
 Path for persistent data. Path is <redis_dir>/redis_<redis_name>/.
 
+#####`redis_pid_dir`
+
+Default is '/var/run' (string).
+Path for pidfile. Full pidfile path is <redis_pid_dir>/redis_<redis_name>.pid.
+
 #####`redis_log_dir`
 
 Default is '/var/log' (string).
@@ -401,6 +406,11 @@ This module is tested on CentOS 6.5 and Debian 7 (Wheezy) and should also run wi
 * RHEL/CentOS/Scientific 6+
 * Debian 6+
 * Ubunutu 10.04 and newer
+* SLES 11 SP3
+
+Limitation on SLES:
+ * Installation from source is not supported
+ * Redis sentinel configuration/management is not supported
 
 ##Contributing
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -25,8 +25,15 @@ class redis::install (
       'Debian', 'Ubuntu': {
         package { 'redis-server' : ensure => $redis_version, }
       }
-      'Fedora', 'RedHat', 'CentOS', 'OEL', 'OracleLinux', 'Amazon', 'Scientific': {
+      'Fedora', 'RedHat', 'CentOS', 'OEL', 'OracleLinux', 'Amazon', 'Scientific', 'SLES': {
         package { 'redis' : ensure => $redis_version, }
+        # The SLES DatabaseServer repository installs a conflicting logrotation configuration
+        if $::operatingsystem == 'SLES' {
+          file { '/etc/logrotate.d/redis':
+            ensure    => 'absent',
+            subscribe => Package['redis'],
+          }
+        }
       }
       default: {
         fail('The module does not support this OS.')

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -75,6 +75,7 @@ define redis::server (
   $redis_dbfilename        = 'dump.rdb',
   $redis_dir               = '/var/lib',
   $redis_log_dir           = '/var/log',
+  $redis_pid_dir           = '/var/run',
   $redis_loglevel          = 'notice',
   $redis_appedfsync        = 'everysec',
   $running                 = true,
@@ -101,6 +102,7 @@ define redis::server (
   $redis_init_script = $::operatingsystem ? {
     /(Debian|Ubuntu)/                               => 'redis/etc/init.d/debian_redis-server.erb',
     /(Fedora|RedHat|CentOS|OEL|OracleLinux|Amazon)/ => 'redis/etc/init.d/redhat_redis-server.erb',
+    /(SLES)/                                        => 'redis/etc/init.d/sles_redis-server.erb',
     default                                         => UNDEF,
   }
   $redis_2_6_or_greater = versioncmp($::redis::install::redis_version,'2.6') >= 0

--- a/metadata.json
+++ b/metadata.json
@@ -10,6 +10,9 @@
       "operatingsystem": "Scientific"
     },
     {
+      "operatingsystem": "SLES"
+    },
+    {
       "operatingsystem": "Debian"
     },
     {

--- a/templates/etc/init.d/debian_redis-sentinel.erb
+++ b/templates/etc/init.d/debian_redis-sentinel.erb
@@ -6,14 +6,14 @@
 # description:  Redis Sentinel is a monitor for redis servers
 # processname: redis-sentinel
 # config:      /etc/redis-sentinel_<%= @sentinel_name %>.conf
-# pidfile:     /var/run/redis-sentinel_<%= @sentinel_name %>.pid
+# pidfile:     <%= @redis_pid_dir %>/redis-sentinel_<%= @sentinel_name %>.pid
 
 # Source function library.
 . /lib/lsb/init-functions
 
 REDIS_EXEC="<%= @redis_install_dir %>/redis-sentinel"
 REDIS_NAME="redis-sentinel_<%= @sentinel_name %>"
-REDIS_PID="/var/run/redis-sentinel_<%= @sentinel_name %>.pid"
+REDIS_PID="<%= @redis_pid_dir %>/redis-sentinel_<%= @sentinel_name %>.pid"
 REDIS_LOCKFILE="/var/lock/redis-sentinel_<%= @sentinel_name %>"
 REDIS_CONF_FILE="/etc/redis-sentinel_<%= @sentinel_name %>.conf"
 

--- a/templates/etc/init.d/debian_redis-server.erb
+++ b/templates/etc/init.d/debian_redis-server.erb
@@ -6,14 +6,14 @@
 # description:  Redis is a persistent key-value database
 # processname: redis-server
 # config:      /etc/redis_<%= @redis_name %>.conf
-# pidfile:     /var/run/redis_<%= @redis_name %>.pid
+# pidfile:     <%= @redis_pid_dir %>/redis_<%= @redis_name %>.pid
 
 # Source function library.
 . /lib/lsb/init-functions
 
 REDIS_EXEC="<%= @redis_install_dir %>/redis-server"
 REDIS_NAME="redis-server_<%= @redis_name %>"
-REDIS_PID="/var/run/redis_<%= @redis_name %>.pid"
+REDIS_PID="<%= @redis_pid_dir %>/redis_<%= @redis_name %>.pid"
 REDIS_LOCKFILE="/var/lock/redis_<%= @redis_name %>"
 REDIS_CONF_FILE="/etc/redis_<%= @redis_name %>.conf"
 

--- a/templates/etc/init.d/redhat_redis-sentinel.erb
+++ b/templates/etc/init.d/redhat_redis-sentinel.erb
@@ -7,7 +7,7 @@
 # processname: redis-server
 # config:      /etc/redis-sentinel_<%= @sentinel_name %>.conf
 # config:      /etc/sysconfig/redis
-# pidfile:     /var/run/redis-sentinel_<%= @sentinel_name %>.pid
+# pidfile:     <%= @redis_pid_dir %>/redis-sentinel_<%= @sentinel_name %>.pid
 
 # Source function library.
 . /etc/rc.d/init.d/functions
@@ -20,7 +20,7 @@
 
 sentinel="<%= @redis_install_dir %>/redis-sentinel"
 prog="redis-sentinel_<%= @sentinel_name %>"
-pidfile="/var/run/redis-sentinel_<%= @sentinel_name %>.pid"
+pidfile="<%= @redis_pid_dir %>/redis-sentinel_<%= @sentinel_name %>.pid"
 logfile="<%= @log_dir -%>/redis-sentinel_<%= @sentinel_name %>.log"
 
 SENTINEL_CONF_FILE="/etc/redis-sentinel_<%= @sentinel_name %>.conf"

--- a/templates/etc/init.d/redhat_redis-server.erb
+++ b/templates/etc/init.d/redhat_redis-server.erb
@@ -7,7 +7,7 @@
 # processname: redis-server
 # config:      /etc/redis_<%= @redis_name %>.conf
 # config:      /etc/sysconfig/redis
-# pidfile:     /var/run/redis_<%= @redis_name %>.pid
+# pidfile:     <%= @redis_pid_dir %>/redis_<%= @redis_name %>.pid
 
 # Source function library.
 . /etc/rc.d/init.d/functions
@@ -20,7 +20,7 @@
 
 redis="<%= @redis_install_dir %>/redis-server"
 prog="redis_<%= @redis_name %>"
-pidfile="/var/run/redis_<%= @redis_name %>.pid"
+pidfile="<%= @redis_pid_dir %>/redis_<%= @redis_name %>.pid"
 
 REDIS_CONF_FILE="/etc/redis_<%= @redis_name %>.conf"
 

--- a/templates/etc/init.d/sles_redis-server.erb
+++ b/templates/etc/init.d/sles_redis-server.erb
@@ -1,0 +1,109 @@
+#!/bin/sh
+
+# System startup script for Redis for OpenSUSE >= 11.4
+#
+# Author: Marcello Barnaba <m.barnaba@ifad.org>
+# Tue Jul 31 17:32:27 CEST 2012
+#
+# LSB-compatible service control script; see http://www.linuxbase.org/spec/
+# Install it in /etc/init.d/redis and run insserv /etc/init.d/redis
+# Define configurations in /etc/init.d/redis/NAME.conf
+#
+# Source: https://gist.github.com/804026
+#
+### BEGIN INIT INFO
+# Provides:          redis_<%= @redis_name %>
+# Required-Start:    $syslog $remote_fs
+# Required-Stop:     $syslog $remote_fs
+# Default-Start:     3 5
+# Default-Stop:      0 1 2 6
+# Short-Description: Redis server
+# Description:       Starts and stops the configured Redis instances
+### END INIT INFO
+
+EXEC=/usr/sbin/redis-server
+USER=redis
+STATE=<%= @redis_pid_dir %>
+CONF=/etc
+PIDFILE=${STATE}/redis_<%= @redis_name %>.pid
+CONFIG=${CONF}/redis_<%= @redis_name %>.conf
+
+. /etc/rc.status
+
+if [ ! -d $STATE ]; then
+  install -d $state -o $USER -g $USER -m 0755 $STATE
+fi
+
+start() {
+    echo -n "Starting Redis <%= @redis_name %> server."
+
+    if [ ! -f ${CONFIG} ]; then
+        echo "$CONFIG not found"
+        rc_failed
+
+    elif [ -f ${PIDFILE} ] && [ -x /proc/`cat ${PIDFILE}` ]; then
+        echo -n "PID file detected, assuming that this instance is already running (PID `cat ${PIDFILE}`)".
+    else
+        rm -f ${PIDFILE}
+        sudo -u $USER $EXEC $CONFIG
+    fi
+    rc_status -v
+}
+
+stop() {
+    echo -n "Stopping Redis server."
+
+    if [ ! -f $PIDFILE ]; then
+        echo -n "not running"
+    else
+        PID=`cat $PIDFILE`
+        CLI='/usr/bin/redis-cli'
+        PASS=`grep ^requirepass $CONFIG | awk '{print $2}'`
+        PORT=`grep ^port $CONFIG | awk '{print $2}'`
+
+        CLI="$CLI -p $PORT"
+        [ -n "$PASS" ] && CLI="$CLI -a $PASS"
+
+        $CLI shutdown
+        echo -n "Waiting... "
+
+        while [ -x /proc/${PID} ]; do
+            sleep 5
+            /sbin/checkproc -p $PIDFILE $EXEC
+        done
+
+        rm -f ${PIDFILE}
+    fi
+    rc_status -v
+}
+
+status() {
+    echo -n "Checking for redis."
+    /sbin/checkproc -p $PIDFILE $EXEC
+    rc_status -v
+}
+
+
+case "$1" in
+    start)
+        start
+    ;;
+
+    stop)
+        stop
+    ;;
+
+    status)
+        status
+    ;;
+
+    restart)
+        $0 stop  $2
+        $0 start $2
+    ;;
+
+    *)
+        echo "Usage: $0 <start|stop|restart|status>"
+        exit 1
+    ;;
+esac

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -15,12 +15,12 @@
 # units are case insensitive so 1GB 1Gb 1gB are all the same.
 
 # By default Redis does not run as a daemon. Use 'yes' if you need it.
-# Note that Redis will write a pid file in /var/run/redis_<%= @redis_name %>.pid when daemonized.
+# Note that Redis will write a pid file in <%= @redis_pid_dir %>/redis_<%= @redis_name %>.pid when daemonized.
 daemonize yes
 
-# When running daemonized, Redis writes a pid file in /var/run/redis.pid by
+# When running daemonized, Redis writes a pid file in <%= @redis_pid_dir %>/redis.pid by
 # default. You can specify a custom pid file location here.
-pidfile /var/run/redis_<%= @redis_name %>.pid
+pidfile <%= @redis_pid_dir %>/redis_<%= @redis_name %>.pid
 
 # Accept connections on the specified port, default is 6379.
 # If port 0 is specified Redis will not listen on a TCP socket.


### PR DESCRIPTION
tested and developed on SLES 11 SP3.

Introduced new variable for redis::server: redis_pid_dir,
since on SLES, the directory used for the PID file is /var/run/redis
The daemon runs as user 'redis', therefore it cannot write directly
into /var/run.
The variable defaults to '/var/run', wherever I found '/var/run'
hardcoded in the templates of other distributions, it's now exchanged
with the variable.

Limitations:
 * Only supports installation from Package
 * No redis sentinal configuration/management support

Note: The redis package installs a conflicting /etc/logrotate.d/redis
file. I added to redis::install a snippet to make sure it's absent.

README.md and metadata.json update accordingly, mentioning support,
limitations and documenting the new variable.

Travis seems to behaving a bit odd Today, just failing with git 
checkouts etc. However, two of the four tests once succeeded for
me, so I'm confident the others should be fine too.
I'll monitor Travis, and try to re-trigger the build if necessary.

any feedback welcome!

cheers,
Sebastian