### PR TITLE
init stop fix

### DIFF
--- a/templates/etc/init.d/redhat_redis-server.erb
+++ b/templates/etc/init.d/redhat_redis-server.erb
@@ -41,7 +41,7 @@ start() {
 
 stop() {
     echo -n $"Stopping $prog: "
-    killproc $prog -QUIT
+    killproc $prog
     retval=$?
     echo
     [ $retval -eq 0 ] && rm -f $lockfile


### PR DESCRIPTION
fix a bug that prevented redis from shutting down gracefully (and without data loss)