### PR TITLE
use already existing redis_timeout param in redis.conf.erb template

### DIFF
--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -38,7 +38,7 @@ bind <%= @redis_ip %>
 # unixsocket /var/run/redis/redis.sock
 
 # Close the connection after a client is idle for N seconds (0 to disable)
-timeout 0
+timeout <%= @redis_timeout %>
 
 # Set server verbosity to 'debug'
 # it can be one of:


### PR DESCRIPTION
The README.md describes the redis_timeout param, but it is not used in the template.  