### PR TITLE
Add unixsocket and maxmemory-samples options

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,9 +230,25 @@ Default is '127.0.0.1' (string). Listen IP of redis.
 
 Listen port of Redis. Default: 6379
 
+#####`redis_usesocket`
+
+To enable unixsocket options. Default: false
+
+#####`redis_socket`
+
+Unix socket to use. Default: /tmp/redis.sock
+
+#####`redis_socketperm`
+
+Permission of socket file. Default: 755
+
 #####`redis_mempolicy`
 
 Algorithm used to manage keys. See Redis docs for possible values. Default: allkeys-lru
+
+#####`redis_memsamples`
+
+Number of samples to use for LRU policies. Default: 3
 
 #####`redis_timeout`
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -12,6 +12,10 @@
 #   Listen IP. Default: 127.0.0.1
 # [*redis_port*]
 #   Listen port of Redis. Default: 6379
+# [*redis_socket*]
+#   Unix socket to use. Default: /tmp/redis.sock
+# [*redis_socketperm*]
+#   Permission of socket file. Default: 755
 # [*redis_mempolicy*]
 #   Algorithm used to manage keys. See Redis docs for possible values. Default: allkeys-lru
 # [*redis_timeout*]
@@ -78,6 +82,8 @@ define redis::server (
   $redis_memory            = '100mb',
   $redis_ip                = '127.0.0.1',
   $redis_port              = 6379,
+  $redis_socket            = '/tmp/redis.sock',
+  $redis_socketperm        = 755,
   $redis_mempolicy         = 'allkeys-lru',
   $redis_timeout           = 0,
   $redis_nr_dbs            = 1,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -20,6 +20,8 @@
 #   Permission of socket file. Default: 755
 # [*redis_mempolicy*]
 #   Algorithm used to manage keys. See Redis docs for possible values. Default: allkeys-lru
+# [*redis_memsamples*]
+#   Number of samples to use for LRU policies. Default: 3
 # [*redis_timeout*]
 #   Default: 0
 # [*redis_nr_dbs*]
@@ -88,6 +90,7 @@ define redis::server (
   $redis_socket            = '/tmp/redis.sock',
   $redis_socketperm        = 755,
   $redis_mempolicy         = 'allkeys-lru',
+  $redis_memsamples        = 3,
   $redis_timeout           = 0,
   $redis_nr_dbs            = 1,
   $redis_dbfilename        = 'dump.rdb',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -12,6 +12,8 @@
 #   Listen IP. Default: 127.0.0.1
 # [*redis_port*]
 #   Listen port of Redis. Default: 6379
+# [*redis_usesocket*]
+#   To enable unixsocket options. Default: false
 # [*redis_socket*]
 #   Unix socket to use. Default: /tmp/redis.sock
 # [*redis_socketperm*]
@@ -82,6 +84,7 @@ define redis::server (
   $redis_memory            = '100mb',
   $redis_ip                = '127.0.0.1',
   $redis_port              = 6379,
+  $redis_usesocket         = false,
   $redis_socket            = '/tmp/redis.sock',
   $redis_socketperm        = 755,
   $redis_mempolicy         = 'allkeys-lru',

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -288,6 +288,7 @@ maxmemory-policy <%= @redis_mempolicy %>
 # using the following configuration directive.
 #
 # maxmemory-samples 3
+maxmemory-samples <%= @redis_memsamples %>
 
 ############################## APPEND ONLY MODE ###############################
 

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -36,6 +36,10 @@ bind <%= @redis_ip %>
 # on a unix socket when not specified.
 #
 # unixsocket /var/run/redis/redis.sock
+<% if @redis_usesocket -%>
+unixsocket <%= @redis_socket %>
+unixsocketperm <%= @redis_socketperm %>
+<% end -%>
 
 # Close the connection after a client is idle for N seconds (0 to disable)
 timeout <%= @redis_timeout %>


### PR DESCRIPTION
Add options for redis config items `unixsocket, unixsocketperms, and maxmemory-samples` to module. Includes an enable/disable option for sockets outside of the raw config values.