### PR TITLE
Avoid conflicts from build-essential

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -45,7 +45,8 @@ class redis::install (
     # install necessary packages for build.
     case $::operatingsystem {
       'Debian', 'Ubuntu': {
-        ensure_packages('build-essential', {'before' => Anchor['redis::prepare_build']} )
+        ensure_packages('build-essential')
+        Package['build-essential'] -> Anchor['redis::prepare_build']
       }
       'Fedora', 'RedHat', 'CentOS', 'OEL', 'OracleLinux', 'Amazon', 'Scientific': {
         ensure_packages(['make', 'gcc', 'glibc-devel'], {'before' => Anchor['redis::prepare_build']})


### PR DESCRIPTION
The `ensure_packages('build-essential', ...)` was conflicting with
another usage of `ensure_packages('build-essential')` elsewhere in our
puppet repository. This change declares the desired dependency in a way
that does not require setting parameters on the package resource.
Because the parameters are removed, the ensure_packages becomes more
generic and less likely to conflict with other modules that might define
the same package resource.