### PR TITLE
add create_ressource from hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ node 'redis-slave.my.domain' {
 }
 ```
 
+### Example using Hiera
+
+    redis::install::redis_package: true
+    redis::install::redis_version: '2:2.8.17-1+deb8u1'
+    redis::servers:
+      'name_server':
+        requirepass: 'strongpass'
+        enabled: true
+        redis_ip: '0.0.0.0'
+        redis_port: '6800'
+        redis_log_dir: '/var/log/redis/'
+
 ###Setting up sentinel with two monitors
 
 You can create multiple sentinels on one node. But most of the time you will

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,16 @@
 #
 # === Parameters
 #
-# None.
+# [*servers*] 
+# Hash for servers instantiation from hiera  
 #
-class redis inherits redis::params {}
+class redis (
+  # START Hiera Lookups ###
+  $servers = {},
+  ### END Hiera Lookups ###
+) inherits redis::params {
+
+  create_resources('redis::server', $servers)
+
+}
+


### PR DESCRIPTION
with this PR we can create redis servers with 

      redis::install::redis_package: true
      redis::install::redis_version: '2:2.8.17-1+deb8u1'
      redis::servers:
       'name_server':
          requirepass: 'strongpass'
          enabled: true
          redis_ip: '0.0.0.0'
          redis_port: '6800'
          redis_log_dir: '/var/log/redis/'

in my hiera node definition.
