### PR TITLE
Explicitly define sentinel's pidfile

### DIFF
--- a/templates/etc/sentinel.conf.erb
+++ b/templates/etc/sentinel.conf.erb
@@ -4,6 +4,8 @@
 
 daemonize yes
 
+pidfile <%= @sentinel_pid_dir %>/redis-sentinel_<%= @sentinel_name %>.pid
+
 logfile <%= @sentinel_log_dir -%>/redis-sentinel_<%= @sentinel_name %>.log
 
 port <%= @sentinel_port -%>


### PR DESCRIPTION
Before this change, the redis-sentinel process was writing its pid to
`/var/run/redis.pid`, preventing the init.d scripts for correctly
identifying in stop and status calls. Tested on redis 3.0.4.