### PR TITLE
Change ownership of $redis_dir depending on the redis system user

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,22 @@ directoy like '/opt/redis-2.8.8/'
 Default is '/usr/bin' (string).
 The dir to which the newly built redis binaries are copied.
 
+#####`redis_user`
+
+Redis system user. Default: undef (string)
+Default 'undef' results to 'root' as redis system user
+
+Some redis install packages create the redis system user by default (at 
+least SLES and Ubuntu provide redis install packages).
+Normally the log directory and the pid directory are created also by
+the redis install package. Therefor, these values must be adjusted too.
+
+
+#####`redis_group`
+
+Redis system group. Default: undef (string)
+Default 'undef' results to 'root' as redis system group
+
 ####Defined Type: `redis::server`
 
 Used to configure redis instances. You can setup multiple redis servers on the

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,12 +14,20 @@
 # [*redis_install_dir*]
 #   The dir to which the newly built redis binaries are copied. Default value is '/usr/bin'.
 #
+# [*redis_user*]
+#   The redis system user. Default value is 'undef', which results to 'root' as system user.
+#
+# [*redis_group*]
+#   The redis system group. Default value is 'undef', which results to 'root' as system group.
+#
 class redis::install (
   $redis_version     = $::redis::params::redis_version,
   $redis_build_dir   = $::redis::params::redis_build_dir,
   $redis_install_dir = $::redis::params::redis_install_dir,
   $redis_package     = $::redis::params::redis_install_package,
-  $download_tool     = $::redis::params::download_tool
+  $download_tool     = $::redis::params::download_tool,
+  $redis_user        = $::redis::params::redis_user,
+  $redis_group       = $::redis::params::redis_group,
 ) inherits redis {
   if ( $redis_package == true ) {
     case $::operatingsystem {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,4 +6,6 @@ class redis::params {
   $redis_install_dir     = '/usr/bin'
   $redis_install_package = false
   $download_tool         = 'curl -s -L'
+  $redis_user            = undef
+  $redis_group           = undef
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -119,6 +119,8 @@ define redis::server (
   $save                    = [],
   $force_rewrite           = false,
 ) {
+  $redis_user              = $::redis::install::redis_user
+  $redis_group             = $::redis::install::redis_group
 
   $redis_install_dir = $::redis::install::redis_install_dir
   $redis_init_script = $::operatingsystem ? {
@@ -164,6 +166,8 @@ define redis::server (
   file { "${redis_dir}/redis_${redis_name}":
     ensure  => directory,
     require => Class['redis::install'],
+    owner   => $redis_user,
+    group   => $redis_group,
   }
 
   # install and configure logrotate

--- a/templates/etc/init.d/sles_redis-server.erb
+++ b/templates/etc/init.d/sles_redis-server.erb
@@ -22,7 +22,8 @@
 ### END INIT INFO
 
 EXEC=/usr/sbin/redis-server
-USER=redis
+USER=<%= @redis_user or 'root' %>
+GROUP=<%= @redis_group or 'root' %>
 STATE=<%= @redis_pid_dir %>
 CONF=/etc
 PIDFILE=${STATE}/redis_<%= @redis_name %>.pid
@@ -31,7 +32,7 @@ CONFIG=${CONF}/redis_<%= @redis_name %>.conf
 . /etc/rc.status
 
 if [ ! -d $STATE ]; then
-  install -d $state -o $USER -g $USER -m 0755 $STATE
+  install -d $state -o $USER -g $GROUP -m 0755 $STATE
 fi
 
 start() {


### PR DESCRIPTION
Some packages, at least the redis package for SLES creates by default a
redis system user. When using the redis cluster feature the $redis_dir
is used for synchronizing. Therefor, the $redis_dir has to be owned by
the redis system user, otherwise the redis server cannot start.

This commit sets the $redis_dir ownership according to the given
$redis_user. By default the $redis_user is undef, which results to
'root' as redis system user.