### PR TITLE
Prevent default redis-server from automatically start

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -33,6 +33,10 @@ class redis::install (
     case $::operatingsystem {
       'Debian', 'Ubuntu': {
         package { 'redis-server' : ensure => $redis_version, }
+        service { 'redis-server' :
+          ensure    => stopped,
+          subscribe => Package['redis-server']
+        }
       }
       'Fedora', 'RedHat', 'CentOS', 'OEL', 'OracleLinux', 'Amazon', 'Scientific', 'SLES': {
         package { 'redis' : ensure => $redis_version, }


### PR DESCRIPTION
When installing the redis-server with an installation package on Ubuntu or
Debian, the redis-server is started automatically. This prevents
the puppet-configured redis-server from a correct start due to a port
conflict.

Stop the redis-server, after you install or upgrade the server with an
installation package.