### PR TITLE
Don't manage the parent directory of all redis instances

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -158,17 +158,6 @@ define redis::server (
     notify  => Service["redis-server_${redis_name}"],
   }
 
-  # path for persistent data
-  # If we specify a directory that's not default we need to pass it as hash
-  # and ensure that we do not have duplicate warning, when we have multiple
-  # redis Instances on one host
-  if ! defined(File[$redis_dir]) {
-    file { $redis_dir:
-      ensure  => directory,
-      require => Class['redis::install'],
-    }
-  }
-
   file { "${redis_dir}/redis_${redis_name}":
     ensure  => directory,
     require => Class['redis::install'],


### PR DESCRIPTION
Hi,

When using the module with its default options, it fails because of a circular dependency.
Upon investigation it turned out to be the '$redis_dir' directory, which defaults to /var/lib.
This patch removes any attempt to manage this directory.

Apart from the issue we see with that resource, it is also very prone to other hidden errors when other modules do something similar. Since the 'defined()' function makes the manifest order dependent when parsing, there is no way of being certain about the eventual catalog except for changing the $redis_dir parameter.

I would argue that removing this block only has impact on people who change the default value _and_ do not create this directory outside the module (which they should anyway, if they want to set mode, owner and/of group).

Regards,
Steven
