### PR TITLE
Notify the server on config changes

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -143,7 +143,8 @@ define redis::server (
       ensure  => file,
       content => template('redis/etc/redis.conf.erb'),
       replace => $force_rewrite,
-      require => Class['redis::install'];
+      require => Class['redis::install'],
+      notify  => Service["redis-server_${redis_name}"],
   }
 
   # startup script


### PR DESCRIPTION
Hi,

The title says it all.
Even when enabling the force_rewrite parameter, Redis doesn't actually restart as the service never receives a notify.

Regards,
Steven
