### PR TITLE
Support for other download URLs than http://download.redis.io

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -88,11 +88,7 @@ class redis::install (
       ensure => directory,
     }
 
-    if $redis_version == $::redis::params::redis_version {
-      $redis_download_url = "${redis_download_base}/redis-stable.tar.gz"
-    } else {
-      $redis_download_url = "${redis_download_base}/releases/redis-${redis_version}.tar.gz"
-    }
+    $redis_download_url = "${redis_download_base}/releases/redis-${redis_version}.tar.gz"
 
     exec { "Download and untar redis ${redis_version}":
       require => File[$redis_build_dir],

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -28,6 +28,7 @@ class redis::install (
   $download_tool     = $::redis::params::download_tool,
   $redis_user        = $::redis::params::redis_user,
   $redis_group       = $::redis::params::redis_group,
+  $redis_download_base  = $::redis::params::redis_download_base,
 ) inherits redis {
   if ( $redis_package == true ) {
     case $::operatingsystem {
@@ -88,9 +89,9 @@ class redis::install (
     }
 
     if $redis_version == $::redis::params::redis_version {
-      $redis_download_url = 'http://download.redis.io/redis-stable.tar.gz'
+      $redis_download_url = "${redis_download_base}/redis-stable.tar.gz"
     } else {
-      $redis_download_url = "http://download.redis.io/releases/redis-${redis_version}.tar.gz"
+      $redis_download_url = "${redis_download_base}/releases/redis-${redis_version}.tar.gz"
     }
 
     exec { "Download and untar redis ${redis_version}":

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -88,7 +88,7 @@ class redis::install (
       ensure => directory,
     }
 
-    $redis_download_url = "${redis_download_base}/releases/redis-${redis_version}.tar.gz"
+    $redis_download_url = "${redis_download_base}/redis-${redis_version}.tar.gz"
 
     exec { "Download and untar redis ${redis_version}":
       require => File[$redis_build_dir],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,5 +8,5 @@ class redis::params {
   $download_tool         = 'curl -s -L'
   $redis_user            = undef
   $redis_group           = undef
-  $redis_download_base	 = 'http://download.redis.io'
+  $redis_download_base	 = 'http://download.redis.io/releases'
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,4 +8,5 @@ class redis::params {
   $download_tool         = 'curl -s -L'
   $redis_user            = undef
   $redis_group           = undef
+  $redis_download_base	 = 'http://download.redis.io'
 }


### PR DESCRIPTION
To set up redis in out environment, we needed to pull the redis tar.gz file from our own web server. I added this functionality to this module by passing a base url parameter to redis::install.