### PR TITLE
Add initial cluster support to redis::server

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -126,6 +126,12 @@ define redis::server (
   $hash_max_ziplist_entries = 512,
   $hash_max_ziplist_value  = 64,
   $manage_logrotate        = true,
+  $cluster_enabled         = false,
+  $cluster_node_timeout          = undef,
+  $cluster_slave_validity_factor = undef,
+  $cluster_migration_barrier     = undef,
+  $cluster_require_full_coverage = true,
+  
 ) {
   $redis_user              = $::redis::install::redis_user
   $redis_group             = $::redis::install::redis_group

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -86,6 +86,25 @@
 #
 # [*manage_logrotate*]
 #   Configure logrotate rules for redis server. Default: true
+#
+# [*cluster_enabled*]
+#   Enable Redis Cluster. Supported only in Redis 3.x. Default: false
+#
+# [*cluster_node_timeout*]
+#   Timeout in ms to declare a node as failed.
+#
+# [*cluster_slave_validity_factor*]
+#   Configure slave validity factor. Please read the Redis documentation to learn more
+#   about this parameter.
+#
+# [*cluster_migration_barrier*]
+#   Slaves migrate to orphaned masters only if there are still at least this
+#   given number of other working slaves for their old master.
+#
+# [*cluster_require_full_coverage*]
+#   By default Redis Cluster nodes stop accepting queries if they detect there
+#   is at least an hash slot uncovered.
+
 define redis::server (
   $redis_name              = $name,
   $redis_memory            = '100mb',
@@ -145,6 +164,7 @@ define redis::server (
     default                                                    => undef,
   }
   $redis_2_6_or_greater = versioncmp($::redis::install::redis_version,'2.6') >= 0
+  $redis_with_cluster_support = versioncmp($::redis::install::redis_version,'3.0') >= 0
 
   # redis conf file
   $conf_file_name = "redis_${redis_name}.conf"

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -403,6 +403,7 @@ auto-aof-rewrite-min-size <%= @aof_rewrite_minsize %>
 # Set it to 0 or a negative value for unlimited execution without warnings.
 #lua-time-limit 5000
 
+<% if @redis_with_cluster_support -%>
 ################################ REDIS CLUSTER  ###############################
 #
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -521,6 +522,7 @@ cluster-migration-barrier <%= @cluster_migration_barrier %>
 # In order to setup your cluster make sure to read the documentation
 # available at http://redis.io web site.
 
+<% end -%>
 ################################## SLOW LOG ###################################
 
 # The Redis Slow Log is a system to log queries that exceeded a specified

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -403,6 +403,124 @@ auto-aof-rewrite-min-size <%= @aof_rewrite_minsize %>
 # Set it to 0 or a negative value for unlimited execution without warnings.
 #lua-time-limit 5000
 
+################################ REDIS CLUSTER  ###############################
+#
+# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# WARNING EXPERIMENTAL: Redis Cluster is considered to be stable code, however
+# in order to mark it as "mature" we need to wait for a non trivial percentage
+# of users to deploy it in production.
+# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#
+# Normal Redis instances can't be part of a Redis Cluster; only nodes that are
+# started as cluster nodes can. In order to start a Redis instance as a
+# cluster node enable the cluster support uncommenting the following:
+#
+# cluster-enabled yes
+<% if @cluster_enabled -%>cluster-enabled yes<% end -%>
+
+# Every cluster node has a cluster configuration file. This file is not
+# intended to be edited by hand. It is created and updated by Redis nodes.
+# Every Redis Cluster node requires a different cluster configuration file.
+# Make sure that instances running in the same system do not have
+# overlapping cluster configuration file names.
+#
+# cluster-config-file nodes-6379.conf
+<%# we're already saving this file in a per-instance directory -#%>
+<% if @cluster_enabled -%>cluster-config-file nodes-cluster.conf<% end -%>
+
+# Cluster node timeout is the amount of milliseconds a node must be unreachable
+# for it to be considered in failure state.
+# Most other internal time limits are multiple of the node timeout.
+#
+# cluster-node-timeout 15000
+<% if @cluster_node_timeout -%>cluster-node-timeout <%= @cluster_node_timeout %><% end -%>
+
+# A slave of a failing master will avoid to start a failover if its data
+# looks too old.
+#
+# There is no simple way for a slave to actually have a exact measure of
+# its "data age", so the following two checks are performed:
+#
+# 1) If there are multiple slaves able to failover, they exchange messages
+#    in order to try to give an advantage to the slave with the best
+#    replication offset (more data from the master processed).
+#    Slaves will try to get their rank by offset, and apply to the start
+#    of the failover a delay proportional to their rank.
+#
+# 2) Every single slave computes the time of the last interaction with
+#    its master. This can be the last ping or command received (if the master
+#    is still in the "connected" state), or the time that elapsed since the
+#    disconnection with the master (if the replication link is currently down).
+#    If the last interaction is too old, the slave will not try to failover
+#    at all.
+#
+# The point "2" can be tuned by user. Specifically a slave will not perform
+# the failover if, since the last interaction with the master, the time
+# elapsed is greater than:
+#
+#   (node-timeout * slave-validity-factor) + repl-ping-slave-period
+#
+# So for example if node-timeout is 30 seconds, and the slave-validity-factor
+# is 10, and assuming a default repl-ping-slave-period of 10 seconds, the
+# slave will not try to failover if it was not able to talk with the master
+# for longer than 310 seconds.
+#
+# A large slave-validity-factor may allow slaves with too old data to failover
+# a master, while a too small value may prevent the cluster from being able to
+# elect a slave at all.
+#
+# For maximum availability, it is possible to set the slave-validity-factor
+# to a value of 0, which means, that slaves will always try to failover the
+# master regardless of the last time they interacted with the master.
+# (However they'll always try to apply a delay proportional to their
+# offset rank).
+#
+# Zero is the only value able to guarantee that when all the partitions heal
+# the cluster will always be able to continue.
+#
+# cluster-slave-validity-factor 10
+<% if @cluster_slave_validity_factor -%>
+cluster-slave-validity-factor <%= @cluster_slave_validity_factor %>
+<% end -%>
+# Cluster slaves are able to migrate to orphaned masters, that are masters
+# that are left without working slaves. This improves the cluster ability
+# to resist to failures as otherwise an orphaned master can't be failed over
+# in case of failure if it has no working slaves.
+#
+# Slaves migrate to orphaned masters only if there are still at least a
+# given number of other working slaves for their old master. This number
+# is the "migration barrier". A migration barrier of 1 means that a slave
+# will migrate only if there is at least 1 other working slave for its master
+# and so forth. It usually reflects the number of slaves you want for every
+# master in your cluster.
+#
+# Default is 1 (slaves migrate only if their masters remain with at least
+# one slave). To disable migration just set it to a very large value.
+# A value of 0 can be set but is useful only for debugging and dangerous
+# in production.
+#
+# cluster-migration-barrier 1
+<% if @cluster_migration_barrier -%>
+cluster-migration-barrier <%= @cluster_migration_barrier %>
+<% end -%>
+
+# By default Redis Cluster nodes stop accepting queries if they detect there
+# is at least an hash slot uncovered (no available node is serving it).
+# This way if the cluster is partially down (for example a range of hash slots
+# are no longer covered) all the cluster becomes, eventually, unavailable.
+# It automatically returns available as soon as all the slots are covered again.
+#
+# However sometimes you want the subset of the cluster which is working,
+# to continue to accept queries for the part of the key space that is still
+# covered. In order to do so, just set the cluster-require-full-coverage
+# option to no.
+#
+# cluster-require-full-coverage yes
+<% if @cluster_require_full_coverage -%>cluster-require-full-coverage yes<% else -%>no<% end -%>
+
+# In order to setup your cluster make sure to read the documentation
+# available at http://redis.io web site.
+
 ################################## SLOW LOG ###################################
 
 # The Redis Slow Log is a system to log queries that exceeded a specified


### PR DESCRIPTION
Hello

with this PR I add basic support for clustering in this module. You still need to run redis-trib.rb to properly initiate the cluster but it's not trivial to puppetize it.
Maybe I should add a check that redis version should be > 3.0?