### PR TITLE
Added two more options to redis.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Most of the time you will only need `redis_version`.
   }
 ```
 To install redis from package use the following parameters.
-You will need `redis_version` and `redis_package`. 
+You will need `redis_version` and `redis_package`.
 ```puppet
   class { 'redis::install':
     redis_version  => '2.8.18-1.el6.remi',
@@ -112,12 +112,16 @@ node 'redis-master.my.domain' {
 
   redis::server {
     'master':
-      redis_memory    => '1g',
-      redis_ip        => '0.0.0.0',
-      redis_port      => 6379,
-      running         => true,
-      enabled         => true,
-      requirepass     => 'some_really_long_random_password',
+      redis_memory               => '1g',
+      redis_ip                   => '0.0.0.0',
+      redis_port                 => 6379,
+      running                    => true,
+      enabled                    => true,
+      requirepass                => 'some_really_long_random_password',
+      client_output_buffer_limit => {
+        'normal' => '0 0 0',
+        'slave'  => '500000000 300000000 60',
+      },
   }
 }
 
@@ -145,7 +149,7 @@ node 'redis-slave.my.domain' {
 Please note that right now you can only create cluster-enabled instances
 but you cannot configure a Redis Cluster only with this module. You should
 still use `redis-trib.rb` from Redis source distribution or configure it
-by hand with redis cluster commands. Moreover, the cluster mode will be enabled 
+by hand with redis cluster commands. Moreover, the cluster mode will be enabled
 only for Redis >= 3.0
 
 A simple example of a cluster-enabled instance, with a timeout of 5 seconds to
@@ -253,7 +257,7 @@ The dir to which the newly built redis binaries are copied.
 Redis system user. Default: undef (string)
 Default 'undef' results to 'root' as redis system user
 
-Some redis install packages create the redis system user by default (at 
+Some redis install packages create the redis system user by default (at
 least SLES and Ubuntu provide redis install packages).
 Normally the log directory and the pid directory are created also by
 the redis install package. Therefor, these values must be adjusted too.
@@ -266,7 +270,7 @@ Default 'undef' results to 'root' as redis system group
 
 #####`download_base`
 
-Url where to find the source tar.gz. 
+Url where to find the source tar.gz.
 Default value is 'http://download.redis.io/releases'
 
 ####Defined Type: `redis::server`
@@ -398,10 +402,16 @@ Configure Redis save snapshotting. Example: [[900, 1], [300, 10]]. Default: []
 
 Boolean. Default: `false`
 
-Configure if the redis config is overwritten by puppet followed by a restart. 
+Configure if the redis config is overwritten by puppet followed by a restart.
 Since redis automatically rewrite their config since
 version 2.8 setting this to `true` will trigger a redis restart on each puppet
 run with redis 2.8 or later.
+
+#####`client_output_buffer_limit`
+
+Hash containing 3 possible classes as keys (normal, slave, pubsub) and with the
+values set to the hard limit, soft limit and seconds.
+Default: empty
 
 #####`manage_logrotate`
 
@@ -428,6 +438,10 @@ Configure Redis slave to be in read-only mode. Default: true (boolean)
 #####`repl_timeout`
 
 Configure Redis slave replication timeout in seconds. Default: 60 (number)
+
+#####`repl_backlog_size`
+
+Configure Redis slave backlog size in bytes. Default: undef
 
 #####`repl_ping_slave_period`
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -69,6 +69,8 @@
 #   Configure Redis slave replication timeout
 # [*repl_ping_slave_period*]
 #   Configure Redis replication ping slave period
+# [*repl_backlog_size*]
+#   Replication backlog size (in bytes or multiples). Default: undef
 # [*save*]
 #   Configure Redis save snapshotting. Example: [[900, 1], [300, 10]]. Default: []
 # [*hash_max_ziplist_entries*]
@@ -83,6 +85,11 @@
 #   Since redis automatically rewrite their config since version 2.8 what conflicts with puppet
 #   the config files created by puppet will be copied to this directory and redis will be started from
 #   this copy.
+#
+# [*client_output_buffer_limit*]
+#   Hash containing 3 possible classes as keys (normal, slave, pubsub) and
+#   with the values set to the hard limit, soft limit and seconds.
+#   Default: empty
 #
 # [*manage_logrotate*]
 #   Configure logrotate rules for redis server. Default: true
@@ -106,46 +113,48 @@
 #   is at least an hash slot uncovered.
 
 define redis::server (
-  $redis_name              = $name,
-  $redis_memory            = '100mb',
-  $redis_ip                = '127.0.0.1',
-  $redis_port              = 6379,
-  $redis_usesocket         = false,
-  $redis_socket            = '/tmp/redis.sock',
-  $redis_socketperm        = 755,
-  $redis_mempolicy         = 'allkeys-lru',
-  $redis_memsamples        = 3,
-  $redis_timeout           = 0,
-  $redis_nr_dbs            = 1,
-  $redis_dbfilename        = 'dump.rdb',
-  $redis_dir               = '/var/lib',
-  $redis_log_dir           = '/var/log',
-  $redis_pid_dir           = '/var/run',
-  $redis_run_dir           = '/var/run/redis',
-  $redis_loglevel          = 'notice',
-  $redis_appedfsync        = 'everysec',
-  $running                 = true,
-  $enabled                 = true,
-  $requirepass             = undef,
-  $maxclients              = undef,
-  $appendfsync_on_rewrite  = false,
-  $aof_rewrite_percentage  = 100,
-  $aof_rewrite_minsize     = 64,
-  $redis_appendfsync       = 'everysec',
-  $redis_enabled_append_file = false,
-  $redis_append_file       = undef,
-  $redis_append_enable     = false,
-  $slaveof                 = undef,
-  $masterauth              = undef,
-  $slave_serve_stale_data  = true,
-  $slave_read_only         = true,
-  $repl_timeout            = 60,
-  $repl_ping_slave_period  = 10,
-  $save                    = [],
-  $hash_max_ziplist_entries = 512,
-  $hash_max_ziplist_value  = 64,
-  $manage_logrotate        = true,
-  $cluster_enabled         = false,
+  $redis_name                    = $name,
+  $redis_memory                  = '100mb',
+  $redis_ip                      = '127.0.0.1',
+  $redis_port                    = 6379,
+  $redis_usesocket               = false,
+  $redis_socket                  = '/tmp/redis.sock',
+  $redis_socketperm              = 755,
+  $redis_mempolicy               = 'allkeys-lru',
+  $redis_memsamples              = 3,
+  $redis_timeout                 = 0,
+  $redis_nr_dbs                  = 1,
+  $redis_dbfilename              = 'dump.rdb',
+  $redis_dir                     = '/var/lib',
+  $redis_log_dir                 = '/var/log',
+  $redis_pid_dir                 = '/var/run',
+  $redis_run_dir                 = '/var/run/redis',
+  $redis_loglevel                = 'notice',
+  $redis_appedfsync              = 'everysec',
+  $running                       = true,
+  $enabled                       = true,
+  $requirepass                   = undef,
+  $maxclients                    = undef,
+  $appendfsync_on_rewrite        = false,
+  $aof_rewrite_percentage        = 100,
+  $aof_rewrite_minsize           = 64,
+  $redis_appendfsync             = 'everysec',
+  $redis_enabled_append_file     = false,
+  $redis_append_file             = undef,
+  $redis_append_enable           = false,
+  $slaveof                       = undef,
+  $masterauth                    = undef,
+  $slave_serve_stale_data        = true,
+  $slave_read_only               = true,
+  $repl_timeout                  = 60,
+  $repl_ping_slave_period        = 10,
+  $repl_backlog_size             = undef,
+  $save                          = [],
+  $hash_max_ziplist_entries      = 512,
+  $hash_max_ziplist_value        = 64,
+  $client_output_buffer_limit    = {},
+  $manage_logrotate              = true,
+  $cluster_enabled               = false,
   $cluster_node_timeout          = undef,
   $cluster_slave_validity_factor = undef,
   $cluster_migration_barrier     = undef,

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -198,6 +198,20 @@ repl-timeout <%= @repl_timeout %>
 # By default the priority is 100.
 #slave-priority 100
 
+# Set the replication backlog size. The backlog is a buffer that accumulates
+# slave data when slaves are disconnected for some time, so that when a slave
+# wants to reconnect again, often a full resync is not needed, but a partial
+# resync is enough, just passing the portion of data the slave missed while
+# disconnected.
+#
+# The bigger the replication backlog, the longer the time the slave can be
+# disconnected and later be able to perform a partial resynchronization.
+#
+# The backlog is only allocated once there is at least a slave connected.
+#
+# repl-backlog-size 1mb
+<% if @repl_backlog_size -%>repl-backlog-size <%= @repl_backlog_size %><% end -%>
+
 ################################## SECURITY ###################################
 
 # Require clients to issue AUTH password before processing any other
@@ -632,9 +646,14 @@ activerehashing yes
 # subscribers and slaves receive data in a push fashion.
 #
 # Both the hard or the soft limit can be disabled just setting it to zero.
+#
 #client-output-buffer-limit normal 0 0 0
 #client-output-buffer-limit slave 256mb 64mb 60
 #client-output-buffer-limit pubsub 32mb 8mb 60
+
+<% @client_output_buffer_limit.sort.each do |key, value| -%>
+client-output-buffer-limit <%= key -%> <%= value %>
+<% end -%>
 
 ################################## INCLUDES ###################################
 


### PR DESCRIPTION
Added two more options to redis.conf:
    - client-output-buffer-limit, as a hash
    - repl_backlog_size, a simple value
    
    Both params are disabled by default as they are in a default redis installation
    and as they were with the previous module version. These params are useful with
    replication and big instances

