### PR TITLE
Add required update-rc.d headers to debian init.d scripts

### DIFF
--- a/templates/etc/init.d/debian_redis-sentinel.erb
+++ b/templates/etc/init.d/debian_redis-sentinel.erb
@@ -1,12 +1,16 @@
 #!/bin/sh
 #
-# redis - this script starts and stops the redis-server daemon
-#
-# chkconfig:   - 85 15
-# description:  Redis Sentinel is a monitor for redis servers
-# processname: redis-sentinel
-# config:      /etc/redis-sentinel_<%= @sentinel_name %>.conf
-# pidfile:     <%= @sentinel_pid_dir %>/redis-sentinel_<%= @sentinel_name %>.pid
+### BEGIN INIT INFO
+# Provides:             redis-sentinel
+# Required-Start:       $syslog $remote_fs
+# Required-Stop:        $syslog $remote_fs
+# Should-Start:         $local_fs
+# Should-Stop:          $local_fs
+# Default-Start:        2 3 4 5 
+# Default-Stop:         0 1 6 
+# Short-Description:    Redis Sentinel is a monitor for redis servers 
+# Description:          Redis Sentinel is a monitor for redis servers
+### END INIT INFO
 
 # Source function library.
 . /lib/lsb/init-functions
@@ -24,7 +28,7 @@ start() {
     local retval
 
     [ -f "$REDIS_CONF_FILE" ] || exit 6
-    [ -d <%= @sentinel_run_dir %> ] mkdir -p <%= @sentinel_run_dir %>
+    [ -d <%= @sentinel_run_dir %> ] || mkdir -p <%= @sentinel_run_dir %>
     cp -u $REDIS_CONF_FILE $RUNTIME_CONF_FILE
 
     log_daemon_msg "Starting $REDIS_NAME"

--- a/templates/etc/init.d/debian_redis-server.erb
+++ b/templates/etc/init.d/debian_redis-server.erb
@@ -1,12 +1,15 @@
 #!/bin/sh
-#
-# redis - this script starts and stops the redis-server daemon
-#
-# chkconfig:   - 85 15
-# description:  Redis is a persistent key-value database
-# processname: redis-server
-# config:      /etc/redis_<%= @redis_name %>.conf
-# pidfile:     <%= @redis_pid_dir %>/redis_<%= @redis_name %>.pid
+### BEGIN INIT INFO
+# Provides:             redis-server_<%= @redis_name %>
+# Required-Start:       $syslog $remote_fs
+# Required-Stop:        $syslog $remote_fs
+# Should-Start:         $local_fs
+# Should-Stop:          $local_fs
+# Default-Start:        2 3 4 5 
+# Default-Stop:         0 1 6 
+# Short-Description:    this script starts and stops the redis-server daemon
+# Description:          this script starts and stops the redis-server daemon
+### END INIT INFO
 
 # Source function library.
 . /lib/lsb/init-functions
@@ -92,7 +95,7 @@ case "$1" in
         restart
         ;;
     reload)
-        rh_status_q || exit 7
+        status_q || exit 7
         reload
         ;;
     status)


### PR DESCRIPTION
Quick fix for missing correct header tags in debian ini.d scripts. Puppet agent log:
Error: Execution of '/usr/sbin/update-rc.d redis-server_myserver defaults' returned 1: update-rc.d: using dependency based boot sequencing
insserv: warning: script 'redis-server_myserver' missing LSB tags and overrides
insserv: There is a loop between service gunicorn and redis-server_myserver if stopped
insserv:  loop involving service redis-server_myserver at depth 2
insserv:  loop involving service gunicorn at depth 1
insserv: Stopping redis-server_myserver depends on gunicorn and therefore on system facility `$all' which can not be true!
insserv: exiting now without changing boot order!
update-rc.d: error: insserv rejected the script header