### PR TITLE
Add support to run under non-root user for CentOS 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,8 @@ gem 'puppet-lint', '>= 0.3.2',            :require => false
 gem 'rspec-puppet', '>= 2.3.2',           :require => false
 gem 'rspec-puppet-facts',                 :require => false
 gem 'metadata-json-lint',                 :require => false
-gem 'rake', '< 11.0.0', # ruby <1.9 versus rake 11.0.0 workaround
-gem 'json', '< 2.0.0'  # ruby <2.0 versus json 2.0.2 workaround
+gem 'json', '< 2.0.0',
+gem 'rake', '< 11.0.0' # ruby <1.9 versus rake 11.0.0 workaround
 
 if File.exists? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'rspec-puppet', '>= 2.3.2',           :require => false
 gem 'rspec-puppet-facts',                 :require => false
 gem 'metadata-json-lint',                 :require => false
 gem 'rake', '< 11.0.0', # ruby <1.9 versus rake 11.0.0 workaround
-gem 'json', '<= 1.8.3'  # ruby <2.0 versus json 2.0.2 workaround
+gem 'json', '< 2.0.0'  # ruby <2.0 versus json 2.0.2 workaround
 
 if File.exists? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,8 @@ gem 'puppet-lint', '>= 0.3.2',            :require => false
 gem 'rspec-puppet', '>= 2.3.2',           :require => false
 gem 'rspec-puppet-facts',                 :require => false
 gem 'metadata-json-lint',                 :require => false
-gem 'rake', '< 11.0.0' # rubi <1.9 versus rake 11.0.0 workaround
+gem 'rake', '< 11.0.0', # ruby <1.9 versus rake 11.0.0 workaround
+gem 'json', '<= 1.8.3'  # ruby <2.0 versus json 2.0.2 workaround
 
 if File.exists? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'rspec-puppet-facts',                 :require => false
 gem 'metadata-json-lint',                 :require => false
 gem 'rake', '< 11.0.0' # ruby <1.9 versus rake 11.0.0 workaround
 gem 'json', '< 2.0.0'  # ruby <2.0 versus json 2.0.2 workaround
+gem 'json_pure', '< 2.0.0'  # same as json
 
 if File.exists? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)

--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,8 @@ gem 'puppet-lint', '>= 0.3.2',            :require => false
 gem 'rspec-puppet', '>= 2.3.2',           :require => false
 gem 'rspec-puppet-facts',                 :require => false
 gem 'metadata-json-lint',                 :require => false
-gem 'json', '< 2.0.0',
 gem 'rake', '< 11.0.0' # ruby <1.9 versus rake 11.0.0 workaround
+gem 'json', '< 2.0.0'  # ruby <2.0 versus json 2.0.2 workaround
 
 if File.exists? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -120,7 +120,7 @@ define redis::server (
   $redis_dbfilename        = 'dump.rdb',
   $redis_dir               = '/var/lib',
   $redis_log_dir           = '/var/log',
-  $redis_pid_dir           = '/var/run',
+  $redis_pid_dir           = '/var/run/redis',
   $redis_run_dir           = '/var/run/redis',
   $redis_loglevel          = 'notice',
   $redis_appedfsync        = 'everysec',
@@ -194,12 +194,21 @@ define redis::server (
       notify  => Exec["systemd_service_${redis_name}_preset"],
     }
   } else {
+    $sysconfig_file = "/etc/sysconfig/redis_${redis_name}"
+    file { $sysconfig_file:
+      ensure  => file,
+      mode    => '0755',
+      content => inline_template("REDIS_USER=<%= @redis_user %>"),
+      notify  => Service["redis-server_${redis_name}"],
+    }
+
     $service_file = "/etc/init.d/redis-server_${redis_name}"
     file { $service_file:
       ensure  => file,
       mode    => '0755',
       content => template($redis_init_script),
       require => [
+        File[$sysconfig_file],
         File[$conf_file],
         File["${redis_dir}/redis_${redis_name}"]
       ],
@@ -223,6 +232,28 @@ define redis::server (
     require => Class['redis::install'],
     owner   => $redis_user,
     group   => $redis_group,
+  }
+
+  # path for pid and runtime config
+  if ! defined(File[$redis_run_dir]) {
+    file { $redis_run_dir:
+      ensure  => directory,
+      require => Class['redis::install'],
+      owner   => 'root',
+      group   => $redis_group,
+      mode    => 0775,
+    }
+  }
+
+  # path for logs
+  if ! defined(File[$redis_log_dir]) {
+    file { $redis_log_dir:
+      ensure  => directory,
+      require => Class['redis::install'],
+      owner   => 'root',
+      group   => $redis_group,
+      mode    => 0775,
+    }
   }
 
   if ($manage_logrotate == true){

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -198,7 +198,7 @@ define redis::server (
     file { $sysconfig_file:
       ensure  => file,
       mode    => '0755',
-      content => inline_template("REDIS_USER=<%= @redis_user %>"),
+      content => inline_template('REDIS_USER=<%= @redis_user %>'),
       notify  => Service["redis-server_${redis_name}"],
     }
 
@@ -241,7 +241,7 @@ define redis::server (
       require => Class['redis::install'],
       owner   => 'root',
       group   => $redis_group,
-      mode    => 0775,
+      mode    => '0775',
     }
   }
 
@@ -252,7 +252,7 @@ define redis::server (
       require => Class['redis::install'],
       owner   => 'root',
       group   => $redis_group,
-      mode    => 0775,
+      mode    => '0775',
     }
   }
 

--- a/templates/etc/init.d/redhat_redis-server.erb
+++ b/templates/etc/init.d/redhat_redis-server.erb
@@ -25,17 +25,17 @@ pidfile="<%= @redis_pid_dir %>/redis_<%= @redis_name %>.pid"
 REDIS_CONF_FILE="/etc/redis_<%= @redis_name %>.conf"
 RUNTIME_CONF_FILE="<%= @redis_run_dir %>/redis_<%= @redis_name %>.conf"
 
-#[ -f /etc/sysconfig/redis ] && . /etc/sysconfig/redis
+[ -f /etc/sysconfig/redis_<%= @redis_name %> ] && . /etc/sysconfig/redis_<%= @redis_name %>
 
 lockfile="/var/lock/subsys/redis_<%= @redis_name %>"
 
 start() {
     [ -x $redis ] || exit 5
     [ -f $REDIS_CONF_FILE ] || exit 6
-    [ -d <%= @redis_pid_dir %> ] || mkdir -p <%= @redis_pid_dir %>
+    [ -d <%= @redis_pid_dir %> ] || exit 7
     echo -n $"Starting $prog: "
     cp -u $REDIS_CONF_FILE $RUNTIME_CONF_FILE
-    daemon $redis $RUNTIME_CONF_FILE
+    daemon --user ${REDIS_USER-redis} --check $prog $redis $RUNTIME_CONF_FILE
     retval=$?
     echo
     [ $retval -eq 0 ] && touch $lockfile
@@ -44,7 +44,7 @@ start() {
 
 stop() {
     echo -n $"Stopping $prog: "
-    killproc $prog
+    killproc -p $pidfile -b $redis $prog
     retval=$?
     echo
     [ $retval -eq 0 ] && rm -f $lockfile
@@ -59,7 +59,7 @@ restart() {
 
 reload() {
     echo -n $"Reloading $prog: "
-    killproc $redis -HUP
+    killproc -p $pidfile -b $redis $prog -HUP
     RETVAL=$?
     echo
 }
@@ -69,7 +69,7 @@ force_reload() {
 }
 
 rh_status() {
-    status -p $pidfile
+    status -p $pidfile -b $redis $prog
     retval=$?
     return $retval
 }


### PR DESCRIPTION
This should allow Redis server instances on CentOS 6 to run under non-root user and take care of the folder permissions accordingly.
