### PR TITLE
Add redis_disable_commands parameter to redis::server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Server: add include parameter for config
 - allows for compatibility with Amazon Linux
 - Add cluster params documentation + enable cluster support
+- Add redis_disable_commands
 
 ## 2016-06-24 - 1.9.0 (Feature/Bugfix release)
 

--- a/README.md
+++ b/README.md
@@ -370,6 +370,10 @@ Max clients of Redis instance. Default: undef (number)
 
 Configure the no-appendfsync-on-rewrite variable. Set to yes to enable the option. Defaults off. Default: false (boolean)
 
+#####`redis_disable_commands`
+
+List of commands to disable on the server. Default: []
+
 #####`aof_rewrite_percentage`
 
 Configure the percentage size difference between the last aof filesize and the newest to trigger a rewrite. Default 100

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -57,6 +57,8 @@
 #   Define the path for the append file. Optional. Default: undef
 # [*redis_append_enable*]
 #   Enable or disable the appendonly file option. Default: false
+# [*redis_disable_commands]
+#   List of commands to disable on the server. Default: []
 # [*slaveof*]
 #   Configure Redis Master on a slave
 # [*masterauth*]
@@ -149,6 +151,7 @@ define redis::server (
   $redis_enabled_append_file     = false,
   $redis_append_file             = undef,
   $redis_append_enable           = false,
+  $redis_disable_commands        = [],
   $slaveof                       = undef,
   $masterauth                    = undef,
   $slave_serve_stale_data        = true,

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -247,6 +247,9 @@ repl-timeout <%= @repl_timeout %>
 # an empty string:
 #
 # rename-command CONFIG ""
+<% @redis_disable_commands.each do |command| -%>
+rename-command <%= command %> ""
+<% end -%>
 
 ################################### LIMITS ####################################
 


### PR DESCRIPTION
Adds the ability to send an command list to redis::server to be disabled in the configuration.