### PR TITLE
Disable default redis-server service

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -39,6 +39,7 @@ class redis::install (
 
         service { 'redis-server':
           ensure    => stopped,
+          enabled   => false,
           subscribe => Package['redis-server']
         }
       }


### PR DESCRIPTION
Disables the default redis-server service installed by the Debian/Ubuntu package, to ensure it doesn't restart on reboot, causing port conflicts and preventing the managed service from starting.

(Follows PR https://github.com/echocat/puppet-redis/pull/51 , which only stops the default redis-server service after a puppet run.)