### PR TITLE
Fix applying systemd for Ubuntu

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -196,12 +196,14 @@ define redis::server (
   case $::osfamily {
     'RedHat': {
       $service_file = "/usr/lib/systemd/system/redis-server_${redis_name}.service"
-      if $::operatingsystemmajrelease >= 7 { $has_systemd = true }
+      if versioncmp($::operatingsystemmajrelease, '7') >= 0 { $has_systemd = true }
     }
     'Debian': {
-      $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"
-      if $::operatingsystemmajrelease >= 8 { $has_systemd = true }
-    }
+        if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '8') >= 0) or ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemmajrelease, '15.04') >= 0) {
+          $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"
+          $has_systemd = true
+        }
+      }
     default:  {
       $has_systemd = false
     }


### PR DESCRIPTION
Systemd is only fully supported in Ubuntu 15.04 and later releases.