### PR TITLE
Make server and sentinel exec names unique #111

### DIFF
--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -110,7 +110,7 @@ define redis::sentinel (
   # startup script
   if ($::osfamily == 'RedHat' and versioncmp($::operatingsystemmajrelease, '7') >=0 and $::operatingsystem != 'Amazon') {
     $service_file = "/usr/lib/systemd/system/redis-sentinel_${sentinel_name}.service"
-    exec { "systemd_service_${sentinel_name}_preset":
+    exec { "systemd_service_sentinel_${sentinel_name}_preset":
       command     => "/bin/systemctl preset redis-sentinel_${sentinel_name}.service",
       notify      => Service["redis-sentinel_${sentinel_name}"],
       refreshonly => true,
@@ -121,7 +121,7 @@ define redis::sentinel (
       mode    => '0755',
       content => template('redis/systemd/sentinel.service.erb'),
       require => File[$conf_file],
-      notify  => Exec["systemd_service_${sentinel_name}_preset"],
+      notify  => Exec["systemd_service_sentinel_${sentinel_name}_preset"],
     }
   } else {
     $service_file = "/etc/init.d/redis-sentinel_${sentinel_name}"

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -208,7 +208,7 @@ define redis::server (
   }
 
   if $has_systemd {
-    exec { "systemd_service_${redis_name}_preset":
+    exec { "systemd_service_server_${redis_name}_preset":
       command     => "/bin/systemctl preset redis-server_${redis_name}.service",
       notify      => Service["redis-server_${redis_name}"],
       refreshonly => true,
@@ -222,7 +222,7 @@ define redis::server (
         File[$conf_file],
         File["${redis_dir}/redis_${redis_name}"]
       ],
-      notify  => Exec["systemd_service_${redis_name}_preset"],
+      notify  => Exec["systemd_service_server_${redis_name}_preset"],
     }
   } else {
     $service_file = "/etc/init.d/redis-server_${redis_name}"


### PR DESCRIPTION
This PR addresses Issue #111 by updating the resource naming for both
execs used to setup the systemd script for managing each service