### PR TITLE
Adding new sentinel configuration options (id/announce-ip/announce-port)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2018-02-01 - 2.1.0 (Feature/Bugfix release)
+
+#### Features:
+
+- Add `redis_disable_commands` parameter to redis::server
+
+#### Bugfixes:
+
+- Fix systemd Ubuntu
+- Systemd: fix permission issue with `redis_run_dir` / `sentinel_run_dir`
+- Some more fixes for init.d
+
 ## 2016-11-15 - 2.0.0 (Feature/Bugfix release)
 
 #### Bugfixes:

--- a/README.md
+++ b/README.md
@@ -555,11 +555,11 @@ Configure logrotate rules for redis server. Default: true
 ##### `announce_ip`
 
 Configure announce-ip in Sentinel configuration.  When announce-ip is provided, the Sentinel will claim the specified IP address
-in HELLO messages used to gossip its presence, instead of auto-detecting the local address as it usually does.
+in HELLO messages used to gossip its presence, instead of auto-detecting the local address as it usually does.  Default: `undef`
 
 ##### `announce_port`
 
-Configure announce-port in Sentinel configuration.  Similarly when announce-port is provided and is valid and non-zero, Sentinel will announce the specified TCP port.
+Configure announce-port in Sentinel configuration.  Similarly when announce-port is provided and is valid and non-zero, Sentinel will announce the specified TCP port.  Default: `undef`
 
 *The above two configuration directives are useful in environments where, because of NAT, Sentinel is reachable from outside via a non-local address.  The two options don't need to be used together, if only announce-ip is provided, the Sentinel will announce the specified IP and the server port as specified by the "port" option. If only announce-port is provided, the Sentinel will announce the auto-detected local IP and the specified port.*
 

--- a/README.md
+++ b/README.md
@@ -552,6 +552,17 @@ run with redis 2.8 or later.
 
 Configure logrotate rules for redis server. Default: true
 
+##### `announce_ip`
+
+Configure announce-ip in Sentinel configuration.  When announce-ip is provided, the Sentinel will claim the specified IP address
+in HELLO messages used to gossip its presence, instead of auto-detecting the local address as it usually does.
+
+##### `announce_port`
+
+Configure announce-port in Sentinel configuration.  Similarly when announce-port is provided and is valid and non-zero, Sentinel will announce the specified TCP port.
+
+*The above two configuration directives are useful in environments where, because of NAT, Sentinel is reachable from outside via a non-local address.  The two options don't need to be used together, if only announce-ip is provided, the Sentinel will announce the specified IP and the server port as specified by the "port" option. If only announce-port is provided, the Sentinel will announce the auto-detected local IP and the specified port.*
+
 ## Limitations
 
 This module is tested on CentOS 6.5 and Debian 7 (Wheezy) and should also run without problems on

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -47,6 +47,13 @@
 #   to this directory and than sentinel will start with this copy.
 # [*manage_logrotate*]
 #   Configure logrotate rules for redis sentinel. Default: true
+# [*announce_ip*]
+#   Configure announce-ip in Sentinel configuration.  When announce-ip is provided,
+#   the Sentinel will claim the specified IP address in HELLO messages used to gossip its presence,
+#   instead of auto-detecting the local address as it usually does.
+# [*announce_port*]
+#   Configure announce-port in Sentinel configuration.  Similarly when announce-port is provided,
+#   and is valid and non-zero, Sentinel will announce the specified TCP port.
 define redis::sentinel (
   $ensure           = 'present',
   $sentinel_name    = $name,
@@ -73,6 +80,8 @@ define redis::sentinel (
   $running          = true,
   $enabled          = true,
   $manage_logrotate = true,
+  $announce_ip      = undef,
+  $announce_port    = undef,
 ) {
   $sentinel_user              = $::redis::install::redis_user
   $sentinel_group             = $::redis::install::redis_group

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -47,6 +47,8 @@
 #   to this directory and than sentinel will start with this copy.
 # [*manage_logrotate*]
 #   Configure logrotate rules for redis sentinel. Default: true
+# [*sentinel_id*]
+#   Configure the Sentinel ID.  (If defined, needs to be a 40 char string).  Default: undef
 # [*announce_ip*]
 #   Configure announce-ip in Sentinel configuration.  When announce-ip is provided,
 #   the Sentinel will claim the specified IP address in HELLO messages used to gossip its presence,
@@ -82,6 +84,7 @@ define redis::sentinel (
   $manage_logrotate = true,
   $announce_ip      = undef,
   $announce_port    = undef,
+  $sentinel_id      = undef,
 ) {
   $sentinel_user              = $::redis::install::redis_user
   $sentinel_group             = $::redis::install::redis_group

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     }
   ],
   "name": "dwerder-redis",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "source": "https://github.com/echocat/puppet-redis.git",
   "author": "Daniel Werdermann",
   "license": "MPL-2.0",

--- a/templates/etc/sentinel.conf.erb
+++ b/templates/etc/sentinel.conf.erb
@@ -23,6 +23,14 @@ protected-mode <%= @protected_mode %>
 
 <% end -%>
 
+<% if @announce_ip then -%>
+sentinel announce-ip <%= @announce_ip %>
+<% end -%>
+
+<% if @announce_port then -%>
+sentinel announce-port <%= @announce_port %>
+<% end -%>
+
 <%
   #rules = scope.lookupvar('redis::sentinel::monitors')
   @monitors.sort.each do |name, rule| -%>

--- a/templates/etc/sentinel.conf.erb
+++ b/templates/etc/sentinel.conf.erb
@@ -31,6 +31,10 @@ sentinel announce-ip <%= @announce_ip %>
 sentinel announce-port <%= @announce_port %>
 <% end -%>
 
+<% if @sentinel_id then -%>
+sentinel myid <%= @sentinel_id %>
+<% end -%>
+
 <%
   #rules = scope.lookupvar('redis::sentinel::monitors')
   @monitors.sort.each do |name, rule| -%>


### PR DESCRIPTION
Adding configuration options for sentinel to define sentinel id, announce-ip,
announce-port, including supporting documentation for usage.  Both new
options will default to undef, and will not affect the template unless
explicitly defined.