### PR TITLE
versioncmp needs >= 0 to have $has_systemd evaluate to true

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -199,15 +199,15 @@ define redis::server (
   case $::operatingsystem {
     'Fedora', 'RedHat', 'CentOS', 'OEL', 'OracleLinux', 'Amazon', 'Scientific': {
       $service_file = "/usr/lib/systemd/system/redis-server_${redis_name}.service"
-      if versioncmp($::operatingsystemmajrelease, '7') > 0 { $has_systemd = true }
+      if versioncmp($::operatingsystemmajrelease, '7') >= 0 { $has_systemd = true }
     }
     'Debian': {
       $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"
-      if versioncmp($::operatingsystemmajrelease, '8') > 0 { $has_systemd = true }
+      if versioncmp($::operatingsystemmajrelease, '8') >= 0 { $has_systemd = true }
     }
     'Ubuntu': {
       $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"
-      if versioncmp($::operatingsystemmajrelease, '14.04') > 0 { $has_systemd = true }
+      if versioncmp($::operatingsystemmajrelease, '14.04') >= 0 { $has_systemd = true }
     }
     default:  {
       $service_file = "/etc/init.d/redis-server_${redis_name}"


### PR DESCRIPTION
This is at least true for the `jessie` distribution.

A puppet run based on your master branch against jessie, will result in a `redis_server_${redis_name}.service` file that has SysV init contents:

```
Notice: /Stage[main]/Filebeat::Service/Service[filebeat]/ensure: ensure changed 'stopped' to 'running'
Info: /Stage[main]/Filebeat::Service/Service[filebeat]: Unscheduling refresh on Service[filebeat]
Notice: /Stage[main]/Redis/Redis::Server[${redis_name}]/File[/etc/systemd/system/redis-server_${redis_name}.service]/content:
--- /etc/systemd/system/redis-server_${redis_name}.service  2017-08-11 15:39:07.360106250 +0000
+++ /tmp/puppet-file20170814-11392-1d3klxu  2017-08-14 07:17:57.192966676 +0000
@@ -1,14 +1,110 @@
-[Unit]
-Description=Redis redis_${redis_name} database server
-After=network.target
-
-[Service]
-ExecStartPre=/bin/mkdir -p /var/run/redis
-ExecStartPre=/bin/cp -u /etc/redis_${redis_name}.conf /var/run/redis/redis_${redis_name}.conf
-ExecStart=/usr/bin/redis-server /var/run/redis/redis_${redis_name}.conf --daemonize no
-ExecStop=/usr/bin/redis-cli -p 6377 shutdown
-User=redis
-Group=redis
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:             redis-server_${redis_name}
+# Required-Start:       $syslog $remote_fs
+# Required-Stop:        $syslog $remote_fs
+# Should-Start:         $local_fs
+# Should-Stop:          $local_fs
+# Default-Start:        2 3 4 5
+# Default-Stop:         0 1 6
+# Short-Description:    this script starts and stops the redis-server daemon
+# Description:          this script starts and stops the redis-server daemon
+### END INIT INFO

```

After the fix below, the redis service file is populated with systemd unit file directives as expected:
```
Notice: /Stage[main]/Redis/Redis::Server${redis_name}/Service[redis-server_${redis_name}]: Triggered 'refresh' from 1 events
Info: Redis::Server${redis_name}]: Unscheduling all events on Redis::Server${redis_name}
Notice: /Stage[main]/Redis/Redis::Server${redis_name}/File[/etc/systemd/system/redis-server_${redis_name}.service]/content:
--- /etc/systemd/system/redis-server_${redis_name}.service	2017-08-14 07:17:57.976966722 +0000
+++ /tmp/puppet-file20170814-16094-b18bql	2017-08-14 07:27:28.996999452 +0000
@@ -1,110 +1,14 @@
-#!/bin/sh
-### BEGIN INIT INFO
-# Provides:             redis-server_${redis_name}
-# Required-Start:       $syslog $remote_fs
-# Required-Stop:        $syslog $remote_fs
-# Should-Start:         $local_fs
-# Should-Stop:          $local_fs
-# Default-Start:        2 3 4 5
-# Default-Stop:         0 1 6
-# Short-Description:    this script starts and stops the redis-server daemon
-# Description:          this script starts and stops the redis-server daemon
-### END INIT INFO
+[Unit]
+Description=Redis redis_${redis_name} database server
+After=network.target
+
+[Service]
+ExecStartPre=/bin/mkdir -p /var/run/redis
+ExecStartPre=/bin/cp -u /etc/redis_${redis_name}.conf /var/run/redis/redis_${redis_name}.conf
+ExecStart=/usr/bin/redis-server /var/run/redis/redis_${redis_name}.conf --daemonize no
+ExecStop=/usr/bin/redis-cli -p 6379 shutdown
+User=redis
+Group=redis

-# Source function library.
-. /lib/lsb/init-functions
-
-REDIS_EXEC="/usr/bin/redis-server"
-REDIS_NAME="redis-server_${redis_name}"
-REDIS_PID="/var/run/redis_${redis_name}.pid"
-REDIS_LOCKFILE="/var/lock/redis_${redis_name}"
-REDIS_CONF_FILE="/etc/redis_${redis_name}.conf"
-RUNTIME_CONF_FILE="/var/run/redis/redis_${redis_name}.conf"
-
-[ -x "$REDIS_EXEC" ] || exit 5
-
-start() {
-    local retval
-
-    [ -f "$REDIS_CONF_FILE" ] || exit 6
-    [ -d /var/run/redis ] ||mkdir -p /var/run/redis
-
-    log_daemon_msg "Starting $REDIS_NAME"
-    cp -u $REDIS_CONF_FILE $RUNTIME_CONF_FILE
-    start-stop-daemon --start --quiet --pidfile "$REDIS_PID" --retry 5 --exec "$REDIS_EXEC" --oknodo -- "$RUNTIME_CONF_FILE"
-
-    retval=$?
-    log_end_msg $retval
-    [ $retval -eq 0 ] && touch "$REDIS_LOCKFILE"
-
-    return $retval
-}
-
-stop() {
-    local retval
-
-    log_daemon_msg "Stopping $REDIS_NAME"
-    start-stop-daemon --stop --quiet --signal QUIT --pidfile "$REDIS_PID" --retry 5 --oknodo --exec "$REDIS_EXEC"
-
-    retval=$?
-    log_end_msg $retval
-    [ $retval -eq 0 ] && rm -f "$REDIS_LOCKFILE"
-
-    return $retval
-}
-
-restart() {
-    stop
-    sleep 1
-    start
-}
-
-reload() {
-    local retval
-
-    log_daemon_msg "Stopping $REDIS_NAME"
-    killproc -p"$pidfile" $redis -HUP
-    start-stop-daemon --stop --quiet --signal HUP --pidfile "$REDIS_PID" --oknodo --exec "$REDIS_EXEC"
-
-    retval=$?
-    log_end_msg $retval
-    return $retval
-}
-
-status() {
-    local retval
-    status_of_proc -p "$REDIS_PID" "$REDIS_EXEC" "$REDIS_NAME"
-    retval=$?
-    return $retval
-}
-
-status_q() {
-    status >/dev/null 2>&1
-}
-
-case "$1" in
-    start)
-        status_q && exit 0
-        start
-        ;;
-    stop)
-        status_q || exit 0
-        stop
-        ;;
-    restart|configtest|force-reload)
-        restart
-        ;;
-    reload)
-        status_q || exit 7
-        reload
-        ;;
-    status)
-        status
-        ;;
-    condrestart|try-restart)
-        status_q || exit 0
-        ;;
-    *)
-        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart|reload|force-reload}"
-        exit 2
-esac
+[Install]
```