### PR TITLE
add has_systemd for ubuntu 16.04

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -209,6 +209,10 @@ define redis::server (
       $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"
       if versioncmp($::operatingsystemmajrelease, '14.04') > 0 { $has_systemd = true }
     }
+    'Ubuntu': {
+      $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"
+      if versioncmp($::operatingsystemmajrelease, '16.04') > 0 { $has_systemd = true }
+    }
     default:  {
       $service_file = "/etc/init.d/redis-server_${redis_name}"
       $has_systemd = false


### PR DESCRIPTION
As the title suggests this ensures the server type is able to correctly configure and start on ubuntu 16.04 systems.

The module seems functional on 16.04 aside from this change.