### PR TITLE
fix sentinel 

### DIFF
--- a/templates/etc/sentinel.conf.erb
+++ b/templates/etc/sentinel.conf.erb
@@ -26,6 +26,7 @@ protected-mode <%= @protected_mode %>
 <%
   #rules = scope.lookupvar('redis::sentinel::monitors')
   @monitors.sort.each do |name, rule| -%>
+
 # monitor <%= name %>
 sentinel monitor <%= name -%> <%= rule['master_host'] -%>  <%= rule['master_port'] -%> <%= rule['quorum'] %>
 sentinel down-after-milliseconds <%= name -%> <%= rule['down_after_milliseconds'] %>


### PR DESCRIPTION
Hi puppet-redis team,

While using puppet-redis on ubuntu 16.04 Xenial, it appeared that the systemd config for the sentinel was not created, thus generating errors when then service is notified to start by puppet.

After a bit of investigation in the code of the manifest `sentinel.pp`, it seems that the config for the sentinel with systemd was not created at all for Ubuntu. I calqued the code from `server.pp`, and got things better on this point.

Then I had an issue with the configuration generated for my sentinel: when having more than one block of server definitions the comment starting the second block was starting at the end of the line of the last definition statement making the sentinel failling to start. So I added a linefeed in the template `sentinel.conf.erb` and now everything is running well.

Thanks very much for your work, I hope my modest contribution will help.
 
