### PR TITLE
Fix condition to make sure Debian 8 is detected with systemd

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -203,7 +203,7 @@ define redis::server (
     }
     'Debian': {
       $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"
-      if versioncmp($::operatingsystemmajrelease, '8') > 0 { $has_systemd = true }
+      if versioncmp($::operatingsystemmajrelease, '7') > 0 { $has_systemd = true }
     }
     'Ubuntu': {
       $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"


### PR DESCRIPTION
Debian 8 is using systemd: https://wiki.debian.org/systemd
_systemd is a system and service manager for Linux. It is the default init system for Debian since Debian Jessie_