### PR TITLE
Add newline to end of sentinel template to fix syntax error with monitors

### DIFF
--- a/templates/etc/sentinel.conf.erb
+++ b/templates/etc/sentinel.conf.erb
@@ -34,4 +34,5 @@ sentinel failover-timeout <%= name -%> <%= rule['failover_timeout'] %>
 <%- if rule['auth-pass'] then %>sentinel auth-pass <%= name -%> <%= rule['auth-pass'] %><% end -%>
 <%- if rule['notification-script'] then %>sentinel notification-script <%= name -%> <%= rule['notification-script'] %><% end -%>
 <%- if rule['client-reconfig-script'] then %>sentinel client-reconfig-script <%= name -%> <%= rule['client-reconfig-script'] %><% end -%>
+
 <% end -%>


### PR DESCRIPTION
Resolves #129 