### PR TITLE
include redis::install class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,12 +14,12 @@ gem 'puppetlabs_spec_helper', '>= 0.1.0', :require => false
 gem 'puppet-lint', '>= 0.3.2',            :require => false
 gem 'rspec-puppet', '>= 2.3.2',           :require => false
 gem 'rspec-puppet-facts',                 :require => false
-gem 'metadata-json-lint',                 :require => false
 # rubi <1.9 versus rake 11.0.0 workaround
 gem 'rake', '< 11.0.0',                   :require => false if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
 gem 'json', '< 2.0.0',                    :require => false if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
 gem 'json_pure', '<= 2.0.1',              :require => false if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
-gem 'parallel_tests', '<= 2.9.0',          :require => false if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
+gem 'parallel_tests', '<= 2.9.0',         :require => false if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
+gem 'metadata-json-lint', '< 1.2.0',      :require => false if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
 
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -200,28 +200,16 @@ define redis::server (
   # startup script
   case $::operatingsystem {
     'Fedora', 'RedHat', 'CentOS', 'OEL', 'OracleLinux', 'Amazon', 'Scientific': {
-      if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
-        $has_systemd = true
-        $service_file = "/usr/lib/systemd/system/redis-server_${redis_name}.service"
-      } else {
-        $service_file = "/etc/init.d/redis-server_${redis_name}"
-      }
+      $service_file = "/usr/lib/systemd/system/redis-server_${redis_name}.service"
+      $has_systemd = versioncmp($::operatingsystemmajrelease, '7') >= 0
     }
     'Debian': {
-      if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
-        $has_systemd = true
-        $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"
-      } else {
-        $service_file = "/etc/init.d/redis-server_${redis_name}"
-      }
+      $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"
+      $has_systemd = versioncmp($::operatingsystemmajrelease, '8') >= 0
     }
     'Ubuntu': {
-      if versioncmp($::operatingsystemmajrelease, '15.04') >= 0 {
-        $has_systemd = true
-        $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"
-      } else {
-        $service_file = "/etc/init.d/redis-server_${redis_name}"
-      }
+      $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"
+      $has_systemd = versioncmp($::operatingsystemmajrelease, '15.04') >= 0
     }
     default:  {
       $has_systemd = false

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -172,6 +172,8 @@ define redis::server (
   $protected_mode                = undef,
   $include                       = [],
 ) {
+  include redis::install
+
   $redis_user              = $::redis::install::redis_user
   $redis_group             = $::redis::install::redis_group
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -200,20 +200,32 @@ define redis::server (
   # startup script
   case $::operatingsystem {
     'Fedora', 'RedHat', 'CentOS', 'OEL', 'OracleLinux', 'Amazon', 'Scientific': {
-      $service_file = "/usr/lib/systemd/system/redis-server_${redis_name}.service"
-      if versioncmp($::operatingsystemmajrelease, '7') > 0 { $has_systemd = true }
+      if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
+        $has_systemd = true
+        $service_file = "/usr/lib/systemd/system/redis-server_${redis_name}.service"
+      } else {
+        $service_file = "/etc/init.d/redis-server_${redis_name}"
+      }
     }
     'Debian': {
-      $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"
-      if versioncmp($::operatingsystemmajrelease, '8') > 0 { $has_systemd = true }
+      if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
+        $has_systemd = true
+        $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"
+      } else {
+        $service_file = "/etc/init.d/redis-server_${redis_name}"
+      }
     }
     'Ubuntu': {
-      $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"
-      if versioncmp($::operatingsystemmajrelease, '14.04') > 0 { $has_systemd = true }
+      if versioncmp($::operatingsystemmajrelease, '15.04') >= 0 {
+        $has_systemd = true
+        $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"
+      } else {
+        $service_file = "/etc/init.d/redis-server_${redis_name}"
+      }
     }
     default:  {
-      $service_file = "/etc/init.d/redis-server_${redis_name}"
       $has_systemd = false
+      $service_file = "/etc/init.d/redis-server_${redis_name}"
     }
   }
 

--- a/templates/etc/sentinel.conf.erb
+++ b/templates/etc/sentinel.conf.erb
@@ -31,7 +31,8 @@ sentinel monitor <%= name -%> <%= rule['master_host'] -%>  <%= rule['master_port
 sentinel down-after-milliseconds <%= name -%> <%= rule['down_after_milliseconds'] %>
 sentinel parallel-syncs <%= name -%> <%= rule['parallel-syncs'] %>
 sentinel failover-timeout <%= name -%> <%= rule['failover_timeout'] %>
-<%- if rule['auth-pass'] then %>sentinel auth-pass <%= name -%> <%= rule['auth-pass'] %><% end -%>
-<%- if rule['notification-script'] then %>sentinel notification-script <%= name -%> <%= rule['notification-script'] %><% end -%>
-<%- if rule['client-reconfig-script'] then %>sentinel client-reconfig-script <%= name -%> <%= rule['client-reconfig-script'] %><% end -%>
+<%- if rule['auth-pass'] then %>sentinel auth-pass <%= name -%> <%= rule['auth-pass'] %><% end %>
+<%- if rule['notification-script'] then %>sentinel notification-script <%= name -%> <%= rule['notification-script'] %><% end %>
+<%- if rule['client-reconfig-script'] then %>sentinel client-reconfig-script <%= name -%> <%= rule['client-reconfig-script'] %><% end %>
+
 <% end -%>

--- a/templates/systemd/redis.service.erb
+++ b/templates/systemd/redis.service.erb
@@ -3,8 +3,15 @@ Description=Redis redis_<%= @redis_name %> database server
 After=network.target
 
 [Service]
+<% if @redis_user and @redis_user != 'root' -%>
+PermissionsStartOnly=true
 ExecStartPre=/bin/mkdir -p <%= @redis_run_dir %>
+ExecStartPre=/bin/chown <%= @redis_user %>:<%= @redis_group or 'root' %> <%= @redis_run_dir %>
+<% else -%>
+ExecStartPre=/bin/mkdir -p <%= @redis_run_dir %>
+<% end -%>
 ExecStartPre=/bin/cp -u <%= @conf_file %> <%= @redis_run_dir %>/<%= @conf_file_name %>
+ExecStartPre=/bin/chown <%= @redis_user or 'root' %>:<%= @redis_group or 'root' %> <%= @redis_run_dir %>/<%= @conf_file_name %>
 ExecStart=/usr/bin/redis-server <%= @redis_run_dir %>/<%= @conf_file_name %> --daemonize no
 ExecStop=/usr/bin/redis-cli -p <%= @redis_port %> shutdown
 User=<%= @redis_user or 'root' %>

--- a/templates/systemd/sentinel.service.erb
+++ b/templates/systemd/sentinel.service.erb
@@ -3,8 +3,15 @@ Description=Redis Sentinel <%= @sentinel_name %>
 After=network.target
 
 [Service]
+<% if @sentinel_user and @sentinel_user != 'root' -%>
+PermissionsStartOnly=true
 ExecStartPre=/bin/mkdir -p <%= @sentinel_run_dir %>
+ExecStartPre=/bin/chown <%= @sentinel_user %>:<%= @sentinel_group or 'root' %> <%= @sentinel_run_dir %>
+<% else -%>
+ExecStartPre=/bin/mkdir -p <%= @sentinel_run_dir %>
+<% end -%>
 ExecStartPre=/bin/cp -u <%= @conf_file %> <%= @sentinel_run_dir %>/<%= @conf_file_name %>
+ExecStartPre=/bin/chown <%= @sentinel_user or 'root' %>:<%= @sentinel_group or 'root' %> <%= @sentinel_run_dir %>/<%= @conf_file_name %>
 ExecStart=/usr/bin/redis-sentinel  <%= @sentinel_run_dir %>/<%= @conf_file_name %> --daemonize no
 ExecStop=/usr/bin/redis-cli -p <%= @sentinel_port %> shutdown
 User=<%= @sentinel_user or 'root' %>


### PR DESCRIPTION
Fixes access to variables from ::redis::install scope when using Hiera.

Failing Hiera example:
```
---
classes:
  - redis

redis::install::redis_package: true
redis::install::redis_version: '3.2.10'
redis::servers:
  'server':
    requirepass: 'password'
    enabled: true
    redis_ip: '0.0.0.0'
    redis_port: '6800'
    redis_log_dir: '/var/log/redis/'
```

Error messages:
```
       Warning: Unknown variable: '::redis::install::redis_user'. at /tmp/kitchen/modules/redis/manifests/server.pp:154:30
       Warning: Unknown variable: '::redis::install::redis_group'. at /tmp/kitchen/modules/redis/manifests/server.pp:155:30
       Warning: Unknown variable: '::redis::install::redis_install_dir'. at /tmp/kitchen/modules/redis/manifests/server.pp:157:24
       Warning: Unknown variable: '::redis::install::redis_version'. at /tmp/kitchen/modules/redis/manifests/server.pp:165:38
       Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, 'versioncmp' parameter 'a' expects a String value, got Undef at /tmp/kitchen/modules/redis/manifests/server.pp:165:27  at /tmp/kitchen/modules/redis/manifests/init.pp:16 on node kitchen-dev01.lan
```