### PR TITLE
include redis::install class

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -172,6 +172,8 @@ define redis::server (
   $protected_mode                = undef,
   $include                       = [],
 ) {
+  include redis::install
+
   $redis_user              = $::redis::install::redis_user
   $redis_group             = $::redis::install::redis_group
 


### PR DESCRIPTION
Fixes access to variables from ::redis::install scope when using Hiera.

Failing Hiera example:
```
---
classes:
  - redis

redis::install::redis_package: true
redis::install::redis_version: '3.2.10'
redis::servers:
  'server':
    requirepass: 'password'
    enabled: true
    redis_ip: '0.0.0.0'
    redis_port: '6800'
    redis_log_dir: '/var/log/redis/'
```

Error messages:
```
       Warning: Unknown variable: '::redis::install::redis_user'. at /tmp/kitchen/modules/redis/manifests/server.pp:154:30
       Warning: Unknown variable: '::redis::install::redis_group'. at /tmp/kitchen/modules/redis/manifests/server.pp:155:30
       Warning: Unknown variable: '::redis::install::redis_install_dir'. at /tmp/kitchen/modules/redis/manifests/server.pp:157:24
       Warning: Unknown variable: '::redis::install::redis_version'. at /tmp/kitchen/modules/redis/manifests/server.pp:165:38
       Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, 'versioncmp' parameter 'a' expects a String value, got Undef at /tmp/kitchen/modules/redis/manifests/server.pp:165:27  at /tmp/kitchen/modules/redis/manifests/init.pp:16 on node kitchen-dev01.lan
```