### PR TITLE
Prevent template from adding newline after last PR

### DIFF
--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -680,4 +680,4 @@ client-output-buffer-limit <%= key -%> <%= value %>
 # include /path/to/other.conf
 <% @include.each do |config| %>
 include <%= config %>
-<% end %>
+<% end -%>


### PR DESCRIPTION
Small fix after the [last PR](https://github.com/echocat/puppet-redis/commit/c630fff40fba097c191e812099044ff768ba12be#diff-ce135a6ee04bb278a86e438f506273b1L680), the template is adding newlines to the file and issuing restarts when there should be no changes to the file unless those options are enabled

```
# include /path/to/local.conf
--
# include /path/to/other.conf
+
```