### PR TITLE
Disable default package redis server instance

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -39,6 +39,7 @@ class redis::install (
 
         service { 'redis-server':
           ensure    => stopped,
+          enable    => false,
           subscribe => Package['redis-server']
         }
       }


### PR DESCRIPTION
If using the OS package, the default redis server is not disabled, just stopped. On package upgrades it will automatically restart, which can lead to some other problems (e.g. if default port 6379 was re-used by a self-defined server, apt will choke and fail on package installation).