### PR TITLE
Fix for custom system init on Debian/Ubuntu

### DIFF
--- a/lib/facter/init_system.rb
+++ b/lib/facter/init_system.rb
@@ -1,0 +1,5 @@
+Facter.add(:init_system) do
+  setcode do
+    Facter::Util::Resolution.exec('readlink /proc/1/exe')
+  end
+end

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -124,16 +124,12 @@ define redis::sentinel (
         $service_file = "/usr/lib/systemd/system/redis-sentinel_${sentinel_name}.service"
       }
     }
-    'Debian': {
-      if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
+    'Debian', 'Ubuntu': {
+      if versioncmp($::init_system, 'systemd') >= 0 {
         $has_systemd = true
         $service_file = "/etc/systemd/system/redis-sentinel_${sentinel_name}.service"
-      }
-    }
-    'Ubuntu': {
-      if versioncmp($::operatingsystemmajrelease, '15.04') >= 0 {
-        $has_systemd = true
-        $service_file = "/etc/systemd/system/redis-sentinel_${sentinel_name}.service"
+      } else {
+        $has_systemd = false
       }
     }
     default:  {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -208,16 +208,12 @@ define redis::server (
         $service_file = "/usr/lib/systemd/system/redis-server_${redis_name}.service"
       }
     }
-    'Debian': {
-      if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
+    'Debian', 'Ubuntu': {
+      if versioncmp($::init_system, 'systemd') >= 0 {
         $has_systemd = true
         $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"
-      }
-    }
-    'Ubuntu': {
-      if versioncmp($::operatingsystemmajrelease, '15.04') >= 0 {
-        $has_systemd = true
-        $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"
+      } else {
+        $has_systemd = false
       }
     }
     default:  {


### PR DESCRIPTION
Since we are not using default system init (`systemd`) on our Debian systems for specific reasons, we were faced with some problems while installing redis services. So, here a little fix for Debian & Ubuntu: It uses facter to read system init from `/proc/1/exec` (instead of using defaults based on OS). 
It works fine on both systems, but I've no experience with other distributions life Fedora, CentOS etc, so I did no changes on that code block.

Cheers! 