### PR TITLE
Redis limitnofiles

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -172,6 +172,11 @@ define redis::server (
   $protected_mode                = undef,
   $include                       = [],
   $systemd_limitnofiles          = undef,
+  $lazyfree_lazy_eviction        = undef,
+  $lazyfree_lazy_expire          = undef,
+  $lazyfree_lazy_server_del      = undef,
+  $slave_lazy_flush              = undef,
+  $always_show_logo              = undef,
 ) {
   include redis::install
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -19,7 +19,7 @@
 # [*redis_socketperm*]
 #   Permission of socket file. Default: 755
 # [*redis_mempolicy*]
-#   Algorithm used to manage keys. See Redis docs for possible values. Default: noeviction
+#   Algorithm used to manage keys. See Redis docs for possible values. Default: allkeys-lru
 # [*redis_memsamples*]
 #   Number of samples to use for LRU policies. Default: 3
 # [*redis_timeout*]
@@ -129,7 +129,7 @@ define redis::server (
   $redis_usesocket               = false,
   $redis_socket                  = '/tmp/redis.sock',
   $redis_socketperm              = 755,
-  $redis_mempolicy               = 'noeviction',
+  $redis_mempolicy               = 'allkeys-lru',
   $redis_memsamples              = 3,
   $redis_timeout                 = 0,
   $redis_nr_dbs                  = 1,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -19,7 +19,7 @@
 # [*redis_socketperm*]
 #   Permission of socket file. Default: 755
 # [*redis_mempolicy*]
-#   Algorithm used to manage keys. See Redis docs for possible values. Default: allkeys-lru
+#   Algorithm used to manage keys. See Redis docs for possible values. Default: noeviction
 # [*redis_memsamples*]
 #   Number of samples to use for LRU policies. Default: 3
 # [*redis_timeout*]
@@ -123,13 +123,13 @@
 
 define redis::server (
   $redis_name                    = $name,
-  $redis_memory                  = '100mb',
+  $redis_memory                  = undef,
   $redis_ip                      = '127.0.0.1',
   $redis_port                    = 6379,
   $redis_usesocket               = false,
   $redis_socket                  = '/tmp/redis.sock',
   $redis_socketperm              = 755,
-  $redis_mempolicy               = 'allkeys-lru',
+  $redis_mempolicy               = 'noeviction',
   $redis_memsamples              = 3,
   $redis_timeout                 = 0,
   $redis_nr_dbs                  = 1,
@@ -171,6 +171,7 @@ define redis::server (
   $cluster_require_full_coverage = true,
   $protected_mode                = undef,
   $include                       = [],
+  $systemd_limitnofiles          = undef,
 ) {
   include redis::install
 

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -280,7 +280,8 @@ rename-command <%= command %> ""
 # errors for write operations, and this may even lead to DB inconsistency.
 #
 # maxmemory <bytes>
-<% if @redis_memory != nil -%>maxmemory <%= @redis_memory %><% end -%>
+#<% if @redis_memory != nil -%>maxmemory <%= @redis_memory %><% end -%>
+<% unless @redis_memory.nil? -%>maxmemory <%= @redis_memory %><% end -%>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
 # is reached? You can select among five behavior:

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -280,7 +280,7 @@ rename-command <%= command %> ""
 # errors for write operations, and this may even lead to DB inconsistency.
 #
 # maxmemory <bytes>
-maxmemory <%= @redis_memory %>
+<% if @redis_memory -%>maxmemory <%= @redis_memory %><% end -%>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
 # is reached? You can select among five behavior:

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -280,10 +280,7 @@ rename-command <%= command %> ""
 # errors for write operations, and this may even lead to DB inconsistency.
 #
 # maxmemory <bytes>
-#<% if @redis_memory != nil -%>maxmemory <%= @redis_memory %><% end -%>
-#<% unless @redis_memory.nil? -%>maxmemory <%= @redis_memory %><% end -%>
-
-maxmemory <%= @redis_memory %>
+<% if @redis_memory -%>maxmemory <%= @redis_memory %><% end -%>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
 # is reached? You can select among five behavior:

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -284,7 +284,6 @@ rename-command <%= command %> ""
 #<% unless @redis_memory.nil? -%>maxmemory <%= @redis_memory %><% end -%>
 
 maxmemory <%= @redis_memory %>
-maxmemory.type <%= @redis_memory.type %>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
 # is reached? You can select among five behavior:

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -374,10 +374,10 @@ maxmemory-samples <%= @redis_memsamples %>
 # in order to instead release memory in a non-blocking way like if UNLINK
 # was called, using the following configuration directives:
 
-<% if @lazyfree_lazy_eviction -%>lazyfree-lazy-eviction <%= @lazyfree_lazy_eviction %><% end %>
-<% if @lazyfree_lazy_expire -%>lazyfree-lazy-expire <%= @lazyfree_lazy_expire %><% end %>
-<% if @lazyfree_lazy_server_del -%>lazyfree-lazy-server-del <%= @lazyfree_lazy_server_del %><% end %>
-<% if @slave_lazy_flush -%>slave-lazy-flush <%= @slave_lazy_flush %><% end %>
+<% if @lazyfree_lazy_eviction -%>lazyfree-lazy-eviction <%= @lazyfree_lazy_eviction %><% end -%>
+<% if @lazyfree_lazy_expire -%>lazyfree-lazy-expire <%= @lazyfree_lazy_expire %><% end -%>
+<% if @lazyfree_lazy_server_del -%>lazyfree-lazy-server-del <%= @lazyfree_lazy_server_del %><% end -%>
+<% if @slave_lazy_flush -%>slave-lazy-flush <%= @slave_lazy_flush %><% end -%>
 
 #### END
 

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -374,10 +374,10 @@ maxmemory-samples <%= @redis_memsamples %>
 # in order to instead release memory in a non-blocking way like if UNLINK
 # was called, using the following configuration directives:
 
-<% if @lazyfree_lazy_eviction -%>lazyfree-lazy-eviction <%= @lazyfree_lazy_eviction %><% end -%>
-<% if @lazyfree_lazy_expire -%>lazyfree-lazy-expire <%= @lazyfree_lazy_expire %><% end -%>
-<% if @lazyfree_lazy_server_del -%>lazyfree-lazy-server-del <%= @lazyfree_lazy_server_del %><% end -%>
-<% if @slave_lazy_flush -%>slave-lazy-flush <%= @slave_lazy_flush %><% end -%>
+<% if @lazyfree_lazy_eviction -%>lazyfree-lazy-eviction <%= @lazyfree_lazy_eviction %><% end %>
+<% if @lazyfree_lazy_expire -%>lazyfree-lazy-expire <%= @lazyfree_lazy_expire %><% end %>
+<% if @lazyfree_lazy_server_del -%>lazyfree-lazy-server-del <%= @lazyfree_lazy_server_del %><% end %>
+<% if @slave_lazy_flush -%>slave-lazy-flush <%= @slave_lazy_flush %><% end %>
 
 #### END
 

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -281,7 +281,10 @@ rename-command <%= command %> ""
 #
 # maxmemory <bytes>
 #<% if @redis_memory != nil -%>maxmemory <%= @redis_memory %><% end -%>
-<% unless @redis_memory.nil? -%>maxmemory <%= @redis_memory %><% end -%>
+#<% unless @redis_memory.nil? -%>maxmemory <%= @redis_memory %><% end -%>
+
+maxmemory <%= @redis_memory %>
+maxmemory.type <%= @redis_memory.type %>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
 # is reached? You can select among five behavior:

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -80,6 +80,18 @@ logfile <%= @redis_log_dir %>/redis_<%= @redis_name %>.log
 # dbid is a number between 0 and 'databases'-1
 databases <%= @redis_nr_dbs %>
 
+#### START
+# Added in Redis 4
+# By default Redis shows an ASCII art logo only when started to log to the
+# standard output and if the standard output is a TTY. Basically this means
+# that normally a logo is displayed only in interactive sessions.
+#
+# However it is possible to force the pre-4.0 behavior and always show a
+# ASCII art logo in startup logs by setting the following option to yes.
+<% if @always_show_logo -%>always-show-logo <%= @always_show_logo %><% end -%>
+
+#### END
+
 ################################ SNAPSHOTTING  #################################
 #
 # Save the DB on disk:
@@ -314,6 +326,60 @@ maxmemory-policy <%= @redis_mempolicy %>
 #
 # maxmemory-samples 3
 maxmemory-samples <%= @redis_memsamples %>
+
+
+#### START
+# Added in Redis 4
+############################# LAZY FREEING ####################################
+
+# Redis has two primitives to delete keys. One is called DEL and is a blocking
+# deletion of the object. It means that the server stops processing new commands
+# in order to reclaim all the memory associated with an object in a synchronous
+# way. If the key deleted is associated with a small object, the time needed
+# in order to execute the DEL command is very small and comparable to most other
+# O(1) or O(log_N) commands in Redis. However if the key is associated with an
+# aggregated value containing millions of elements, the server can block for
+# a long time (even seconds) in order to complete the operation.
+#
+# For the above reasons Redis also offers non blocking deletion primitives
+# such as UNLINK (non blocking DEL) and the ASYNC option of FLUSHALL and
+# FLUSHDB commands, in order to reclaim memory in background. Those commands
+# are executed in constant time. Another thread will incrementally free the
+# object in the background as fast as possible.
+#
+# DEL, UNLINK and ASYNC option of FLUSHALL and FLUSHDB are user-controlled.
+# It's up to the design of the application to understand when it is a good
+# idea to use one or the other. However the Redis server sometimes has to
+# delete keys or flush the whole database as a side effect of other operations.
+# Specifically Redis deletes objects independently of a user call in the
+# following scenarios:
+#
+# 1) On eviction, because of the maxmemory and maxmemory policy configurations,
+#    in order to make room for new data, without going over the specified
+#    memory limit.
+# 2) Because of expire: when a key with an associated time to live (see the
+#    EXPIRE command) must be deleted from memory.
+# 3) Because of a side effect of a command that stores data on a key that may
+#    already exist. For example the RENAME command may delete the old key
+#    content when it is replaced with another one. Similarly SUNIONSTORE
+#    or SORT with STORE option may delete existing keys. The SET command
+#    itself removes any old content of the specified key in order to replace
+#    it with the specified string.
+# 4) During replication, when a slave performs a full resynchronization with
+#    its master, the content of the whole database is removed in order to
+#    load the RDB file just transfered.
+#
+# In all the above cases the default is to delete objects in a blocking way,
+# like if DEL was called. However you can configure each case specifically
+# in order to instead release memory in a non-blocking way like if UNLINK
+# was called, using the following configuration directives:
+
+<% if @lazyfree_lazy_eviction -%>lazyfree-lazy-eviction <%= @lazyfree_lazy_eviction %><% end -%>
+<% if @lazyfree_lazy_expire -%>lazyfree-lazy-expire <%= @lazyfree_lazy_expire %><% end -%>
+<% if @lazyfree_lazy_server_del -%>lazyfree-lazy-server-del <%= @lazyfree_lazy_server_del %><% end -%>
+<% if @slave_lazy_flush -%>slave-lazy-flush <%= @slave_lazy_flush %><% end -%>
+
+#### END
 
 ############################## APPEND ONLY MODE ###############################
 

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -280,7 +280,7 @@ rename-command <%= command %> ""
 # errors for write operations, and this may even lead to DB inconsistency.
 #
 # maxmemory <bytes>
-<% if @redis_memory -%>maxmemory <%= @redis_memory %><% end -%>
+<% if @redis_memory != nil -%>maxmemory <%= @redis_memory %><% end -%>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
 # is reached? You can select among five behavior:

--- a/templates/systemd/redis.service.erb
+++ b/templates/systemd/redis.service.erb
@@ -16,7 +16,9 @@ ExecStart=/usr/bin/redis-server <%= @redis_run_dir %>/<%= @conf_file_name %> --d
 ExecStop=/usr/bin/redis-cli -p <%= @redis_port %> shutdown
 User=<%= @redis_user or 'root' %>
 Group=<%= @redis_group or 'root' %>
-<% if @systemd_limitnofiles -%>LimitNOFILE=<%= @systemd_limitnofiles %><% end %>
+<% if @systemd_limitnofiles -%>
+LimitNOFILE=<%= @systemd_limitnofiles %>
+<% end -%>
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/systemd/redis.service.erb
+++ b/templates/systemd/redis.service.erb
@@ -16,7 +16,7 @@ ExecStart=/usr/bin/redis-server <%= @redis_run_dir %>/<%= @conf_file_name %> --d
 ExecStop=/usr/bin/redis-cli -p <%= @redis_port %> shutdown
 User=<%= @redis_user or 'root' %>
 Group=<%= @redis_group or 'root' %>
-<% if @systemd_limitnofiles -%>LimitNOFILE=<%= @systemd_limitnofiles %><% end -%>
+<% if @systemd_limitnofiles -%>LimitNOFILE=<%= @systemd_limitnofiles %><% end %>
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/systemd/redis.service.erb
+++ b/templates/systemd/redis.service.erb
@@ -16,6 +16,7 @@ ExecStart=/usr/bin/redis-server <%= @redis_run_dir %>/<%= @conf_file_name %> --d
 ExecStop=/usr/bin/redis-cli -p <%= @redis_port %> shutdown
 User=<%= @redis_user or 'root' %>
 Group=<%= @redis_group or 'root' %>
+<% if @systemd_limitnofiles -%>LimitNOFILE=<%= @systemd_limitnofiles %><% end -%>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
These changes will let us manage Redis version 4 where a few new parameters were introduced. It also removes the hard coded default for `redis_memory`  and changes the default for `redis_mempolicy`.

New in Redis 4
* $lazyfree_lazy_eviction
* $lazyfree_lazy_expire
* $lazyfree_lazy_server_del
* $slave_lazy_flush
* $always_show_logo

These CAN NOT be set for Redis 3, the service will refuse to start.
For Redis 4 they are optional.

No defaults are set.